### PR TITLE
feat(TASK-031): 设计YAML配置文件解析机制，替代硬编码参数

### DIFF
--- a/examples/configs/pipeline_base.yaml
+++ b/examples/configs/pipeline_base.yaml
@@ -1,0 +1,24 @@
+# Base Pipeline Configuration
+version: "local"
+save_folder: "results"
+exp_name: "experiment_001"
+
+# Evaluation settings
+save_metric: true
+metric_names:
+  - "psnr"
+  - "ssim"
+  - "niqe"
+  - "brisque"
+
+# Image saving
+save_img: true
+img_norm: false
+
+# Dataloader settings (test)
+bs_test: 1
+nw_test: 0
+pin_memory: false
+
+# Mode
+_mode: "single_mode"

--- a/examples/configs/pipeline_ensemble.yaml
+++ b/examples/configs/pipeline_ensemble.yaml
@@ -1,0 +1,23 @@
+# Ensemble Pipeline Configuration
+version: "local"
+save_folder: "results"
+exp_name: "ensemble_experiment_001"
+
+# Evaluation settings
+save_metric: true
+metric_names:
+  - "psnr"
+  - "ssim"
+  - "niqe"
+
+# Image saving
+save_img: true
+img_norm: false
+
+# Dataloader settings (test)
+bs_test: 1
+nw_test: 0
+pin_memory: false
+
+# Mode
+_mode: "multi_mode"

--- a/examples/configs/pipeline_train.yaml
+++ b/examples/configs/pipeline_train.yaml
@@ -1,0 +1,51 @@
+# Training Pipeline Configuration
+version: "local"
+save_folder: "results"
+exp_name: "train_experiment_001"
+
+# Evaluation settings
+save_metric: true
+metric_names:
+  - "psnr"
+  - "ssim"
+
+# Image saving
+save_img: true
+img_norm: false
+
+# Dataloader settings (test)
+bs_test: 1
+nw_test: 0
+pin_memory: false
+
+# Training parameters
+epochs: 100
+steps_per_save_imgs: 10
+steps_per_save_ckpt: 10
+steps_per_cal_metrics: 10
+steps_grad_accumulation: 4
+
+# Training mode
+_mode: "train_mode"
+
+# Tensorboard
+use_tensorboard: true
+
+# Random seed
+seed: 521
+
+# Dataloader settings (train)
+bs_train: 8
+nw_train: 4
+
+# Optimizer and scheduler
+optimizer_cfg:
+  type: "adam"
+  lr: 0.001
+  betas: [0.9, 0.999]
+  eps: 1.0e-08
+  weight_decay: 0
+
+# Loss weights
+loss_weight_dict:
+  l1: 1.0

--- a/spikezoo/config/__init__.py
+++ b/spikezoo/config/__init__.py
@@ -1,0 +1,11 @@
+from .config_manager import ConfigManager, load_config, save_config
+from .pipeline_configs import PipelineConfig, TrainPipelineConfig, EnsemblePipelineConfig
+
+__all__ = [
+    "ConfigManager",
+    "load_config",
+    "save_config",
+    "PipelineConfig",
+    "TrainPipelineConfig",
+    "EnsemblePipelineConfig"
+]

--- a/spikezoo/config/config_manager.py
+++ b/spikezoo/config/config_manager.py
@@ -1,0 +1,83 @@
+import yaml
+import json
+from pathlib import Path
+from typing import Any, Dict, Union
+import logging
+
+
+class ConfigManager:
+    """Configuration manager for YAML/JSON config files."""
+    
+    @staticmethod
+    def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
+        """
+        Load configuration from YAML or JSON file.
+        
+        Args:
+            config_path: Path to the configuration file
+            
+        Returns:
+            Configuration dictionary
+        """
+        config_path = Path(config_path)
+        
+        if not config_path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {config_path}")
+            
+        with open(config_path, 'r', encoding='utf-8') as f:
+            if config_path.suffix.lower() in ['.yaml', '.yml']:
+                config = yaml.safe_load(f)
+            elif config_path.suffix.lower() == '.json':
+                config = json.load(f)
+            else:
+                raise ValueError(f"Unsupported config file format: {config_path.suffix}")
+                
+        return config or {}
+    
+    @staticmethod
+    def save_config(config: Dict[str, Any], config_path: Union[str, Path], format: str = 'yaml') -> None:
+        """
+        Save configuration to YAML or JSON file.
+        
+        Args:
+            config: Configuration dictionary
+            config_path: Path to save the configuration file
+            format: Output format ('yaml' or 'json')
+        """
+        config_path = Path(config_path)
+        
+        # Create parent directories if they don't exist
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(config_path, 'w', encoding='utf-8') as f:
+            if format.lower() in ['yaml', 'yml']:
+                yaml.dump(config, f, default_flow_style=False, allow_unicode=True, indent=2)
+            elif format.lower() == 'json':
+                json.dump(config, f, ensure_ascii=False, indent=2)
+            else:
+                raise ValueError(f"Unsupported config format: {format}")
+
+
+def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
+    """
+    Load configuration from file.
+    
+    Args:
+        config_path: Path to the configuration file
+        
+    Returns:
+        Configuration dictionary
+    """
+    return ConfigManager.load_config(config_path)
+
+
+def save_config(config: Dict[str, Any], config_path: Union[str, Path], format: str = 'yaml') -> None:
+    """
+    Save configuration to file.
+    
+    Args:
+        config: Configuration dictionary
+        config_path: Path to save the configuration file
+        format: Output format ('yaml' or 'json')
+    """
+    ConfigManager.save_config(config, config_path, format)

--- a/spikezoo/config/pipeline_configs.py
+++ b/spikezoo/config/pipeline_configs.py
@@ -1,0 +1,126 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Literal, Union
+from spikezoo.utils.optimizer_utils import OptimizerConfig, AdamOptimizerConfig
+from spikezoo.utils.scheduler_utils import SchedulerConfig
+import yaml
+
+
+@dataclass
+class PipelineConfig:
+    """Base pipeline configuration."""
+    # Model loading
+    version: Literal["local", "v010", "v023"] = "local"
+    
+    # Save settings
+    save_folder: str = ""
+    exp_name: str = ""
+    
+    # Evaluation settings
+    save_metric: bool = True
+    metric_names: List[str] = field(default_factory=lambda: ["psnr", "ssim", "niqe", "brisque"])
+    
+    # Image saving
+    save_img: bool = True
+    img_norm: bool = False
+    
+    # Dataloader settings (test)
+    bs_test: int = 1
+    nw_test: int = 0
+    pin_memory: bool = False
+    
+    # Mode
+    _mode: Literal["single_mode", "multi_mode", "train_mode"] = "single_mode"
+    
+    @classmethod
+    def from_dict(cls, config_dict: dict):
+        """Create PipelineConfig from dictionary."""
+        # Filter out keys that are not in the dataclass fields
+        filtered_dict = {k: v for k, v in config_dict.items() if k in cls.__dataclass_fields__}
+        return cls(**filtered_dict)
+    
+    def to_dict(self):
+        """Convert PipelineConfig to dictionary."""
+        return {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
+
+
+@dataclass
+class TrainPipelineConfig(PipelineConfig):
+    """Training pipeline configuration."""
+    # Training parameters
+    epochs: int = 10
+    steps_per_save_imgs: int = 10
+    steps_per_save_ckpt: int = 10
+    steps_per_cal_metrics: int = 10
+    steps_grad_accumulation: int = 4
+    
+    # Training mode
+    _mode: Literal["single_mode", "multi_mode", "train_mode"] = "train_mode"
+    
+    # Tensorboard
+    use_tensorboard: bool = True
+    
+    # Random seed
+    seed: int = 521
+    
+    # Dataloader settings (train)
+    bs_train: int = 8
+    nw_train: int = 4
+    
+    # Optimizer and scheduler
+    optimizer_cfg: OptimizerConfig = field(default_factory=lambda: AdamOptimizerConfig(lr=1e-3))
+    scheduler_cfg: Optional[SchedulerConfig] = None
+    
+    # Loss weights
+    loss_weight_dict: Dict[Literal["l1", "l2"], float] = field(default_factory=lambda: {"l1": 1})
+    
+    @classmethod
+    def from_dict(cls, config_dict: dict):
+        """Create TrainPipelineConfig from dictionary."""
+        # Handle optimizer config
+        if "optimizer_cfg" in config_dict and isinstance(config_dict["optimizer_cfg"], dict):
+            opt_cfg_dict = config_dict["optimizer_cfg"]
+            opt_type = opt_cfg_dict.get("type", "adam")
+            if opt_type.lower() == "adam":
+                config_dict["optimizer_cfg"] = AdamOptimizerConfig(**{k: v for k, v in opt_cfg_dict.items() if k != "type"})
+            else:
+                # For other optimizer types, use default
+                config_dict["optimizer_cfg"] = AdamOptimizerConfig(lr=1e-3)
+        
+        # Filter out keys that are not in the dataclass fields
+        filtered_dict = {k: v for k, v in config_dict.items() if k in cls.__dataclass_fields__}
+        return cls(**filtered_dict)
+
+
+@dataclass
+class EnsemblePipelineConfig(PipelineConfig):
+    """Ensemble pipeline configuration."""
+    _mode: Literal["single_mode", "multi_mode", "train_mode"] = "multi_mode"
+    
+    @classmethod
+    def from_dict(cls, config_dict: dict):
+        """Create EnsemblePipelineConfig from dictionary."""
+        # Filter out keys that are not in the dataclass fields
+        filtered_dict = {k: v for k, v in config_dict.items() if k in cls.__dataclass_fields__}
+        return cls(**filtered_dict)
+
+
+def load_pipeline_config(config_path: str, config_type: str = "base") -> Union[PipelineConfig, TrainPipelineConfig, EnsemblePipelineConfig]:
+    """
+    Load pipeline configuration from YAML file.
+    
+    Args:
+        config_path: Path to the configuration file
+        config_type: Type of configuration ("base", "train", "ensemble")
+        
+    Returns:
+        PipelineConfig instance
+    """
+    with open(config_path, 'r', encoding='utf-8') as f:
+        config_dict = yaml.safe_load(f) or {}
+    
+    if config_type == "train":
+        return TrainPipelineConfig.from_dict(config_dict)
+    elif config_type == "ensemble":
+        return EnsemblePipelineConfig.from_dict(config_dict)
+    else:
+        return PipelineConfig.from_dict(config_dict)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,159 @@
+import unittest
+import tempfile
+import os
+import yaml
+import json
+from pathlib import Path
+from spikezoo.config.config_manager import ConfigManager, load_config, save_config
+
+
+class TestConfigManager(unittest.TestCase):
+    """ConfigManager unit tests."""
+    
+    def setUp(self):
+        """Test setup."""
+        self.temp_dir = tempfile.mkdtemp()
+        
+    def tearDown(self):
+        """Test cleanup."""
+        # Remove temporary directory
+        for root, dirs, files in os.walk(self.temp_dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self.temp_dir)
+    
+    def test_load_yaml_config(self):
+        """Test loading YAML configuration."""
+        # Create a test YAML config
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp",
+            "save_metric": True,
+            "metric_names": ["psnr", "ssim"]
+        }
+        
+        config_path = Path(self.temp_dir) / "test_config.yaml"
+        with open(config_path, 'w') as f:
+            yaml.dump(config_data, f)
+        
+        # Load config
+        loaded_config = ConfigManager.load_config(config_path)
+        
+        # Check if data matches
+        self.assertEqual(loaded_config, config_data)
+    
+    def test_load_json_config(self):
+        """Test loading JSON configuration."""
+        # Create a test JSON config
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp",
+            "save_metric": True,
+            "metric_names": ["psnr", "ssim"]
+        }
+        
+        config_path = Path(self.temp_dir) / "test_config.json"
+        with open(config_path, 'w') as f:
+            json.dump(config_data, f)
+        
+        # Load config
+        loaded_config = ConfigManager.load_config(config_path)
+        
+        # Check if data matches
+        self.assertEqual(loaded_config, config_data)
+    
+    def test_load_nonexistent_config(self):
+        """Test loading nonexistent configuration."""
+        config_path = Path(self.temp_dir) / "nonexistent.yaml"
+        
+        with self.assertRaises(FileNotFoundError):
+            ConfigManager.load_config(config_path)
+    
+    def test_save_yaml_config(self):
+        """Test saving YAML configuration."""
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp",
+            "save_metric": True,
+            "metric_names": ["psnr", "ssim"]
+        }
+        
+        config_path = Path(self.temp_dir) / "saved_config.yaml"
+        ConfigManager.save_config(config_data, config_path, format='yaml')
+        
+        # Check if file exists
+        self.assertTrue(os.path.exists(config_path))
+        
+        # Load and verify
+        with open(config_path, 'r') as f:
+            saved_data = yaml.safe_load(f)
+        
+        self.assertEqual(saved_data, config_data)
+    
+    def test_save_json_config(self):
+        """Test saving JSON configuration."""
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp",
+            "save_metric": True,
+            "metric_names": ["psnr", "ssim"]
+        }
+        
+        config_path = Path(self.temp_dir) / "saved_config.json"
+        ConfigManager.save_config(config_data, config_path, format='json')
+        
+        # Check if file exists
+        self.assertTrue(os.path.exists(config_path))
+        
+        # Load and verify
+        with open(config_path, 'r') as f:
+            saved_data = json.load(f)
+        
+        self.assertEqual(saved_data, config_data)
+    
+    def test_save_config_with_nested_directories(self):
+        """Test saving configuration to nested directories."""
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp"
+        }
+        
+        config_path = Path(self.temp_dir) / "nested" / "directories" / "config.yaml"
+        ConfigManager.save_config(config_data, config_path)
+        
+        # Check if file exists
+        self.assertTrue(os.path.exists(config_path))
+        
+        # Load and verify
+        loaded_config = ConfigManager.load_config(config_path)
+        self.assertEqual(loaded_config, config_data)
+    
+    def test_convenience_functions(self):
+        """Test convenience load_config and save_config functions."""
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "test_exp"
+        }
+        
+        config_path = Path(self.temp_dir) / "convenience_test.yaml"
+        
+        # Save using convenience function
+        save_config(config_data, config_path)
+        
+        # Load using convenience function
+        loaded_config = load_config(config_path)
+        
+        # Verify data
+        self.assertEqual(loaded_config, config_data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pipeline_configs.py
+++ b/tests/test_pipeline_configs.py
@@ -1,0 +1,294 @@
+import unittest
+import tempfile
+import os
+from pathlib import Path
+from spikezoo.config.pipeline_configs import (
+    PipelineConfig, 
+    TrainPipelineConfig, 
+    EnsemblePipelineConfig,
+    load_pipeline_config
+)
+
+
+class TestPipelineConfigs(unittest.TestCase):
+    """PipelineConfigs unit tests."""
+    
+    def setUp(self):
+        """Test setup."""
+        self.temp_dir = tempfile.mkdtemp()
+        
+    def tearDown(self):
+        """Test cleanup."""
+        # Remove temporary directory
+        for root, dirs, files in os.walk(self.temp_dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self.temp_dir)
+    
+    def test_pipeline_config_creation(self):
+        """Test PipelineConfig creation."""
+        config = PipelineConfig(
+            version="local",
+            save_folder="results",
+            exp_name="test_exp",
+            save_metric=True,
+            metric_names=["psnr", "ssim"],
+            save_img=True,
+            img_norm=False,
+            bs_test=1,
+            nw_test=0,
+            pin_memory=False,
+            _mode="single_mode"
+        )
+        
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "test_exp")
+        self.assertTrue(config.save_metric)
+        self.assertEqual(config.metric_names, ["psnr", "ssim"])
+        self.assertTrue(config.save_img)
+        self.assertFalse(config.img_norm)
+        self.assertEqual(config.bs_test, 1)
+        self.assertEqual(config.nw_test, 0)
+        self.assertFalse(config.pin_memory)
+        self.assertEqual(config._mode, "single_mode")
+    
+    def test_pipeline_config_from_dict(self):
+        """Test PipelineConfig creation from dictionary."""
+        config_dict = {
+            "version": "v010",
+            "save_folder": "outputs",
+            "exp_name": "dict_test",
+            "save_metric": False,
+            "metric_names": ["psnr"],
+            "save_img": False,
+            "img_norm": True,
+            "bs_test": 2,
+            "nw_test": 1,
+            "pin_memory": True,
+            "_mode": "multi_mode"
+        }
+        
+        config = PipelineConfig.from_dict(config_dict)
+        
+        self.assertEqual(config.version, "v010")
+        self.assertEqual(config.save_folder, "outputs")
+        self.assertEqual(config.exp_name, "dict_test")
+        self.assertFalse(config.save_metric)
+        self.assertEqual(config.metric_names, ["psnr"])
+        self.assertFalse(config.save_img)
+        self.assertTrue(config.img_norm)
+        self.assertEqual(config.bs_test, 2)
+        self.assertEqual(config.nw_test, 1)
+        self.assertTrue(config.pin_memory)
+        self.assertEqual(config._mode, "multi_mode")
+    
+    def test_train_pipeline_config_creation(self):
+        """Test TrainPipelineConfig creation."""
+        config = TrainPipelineConfig(
+            version="local",
+            save_folder="results",
+            exp_name="train_test",
+            epochs=50,
+            steps_per_save_imgs=5,
+            steps_per_save_ckpt=5,
+            steps_per_cal_metrics=5,
+            steps_grad_accumulation=2,
+            _mode="train_mode",
+            use_tensorboard=True,
+            seed=42,
+            bs_train=4,
+            nw_train=2,
+            loss_weight_dict={"l1": 0.5}
+        )
+        
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "train_test")
+        self.assertEqual(config.epochs, 50)
+        self.assertEqual(config.steps_per_save_imgs, 5)
+        self.assertEqual(config.steps_per_save_ckpt, 5)
+        self.assertEqual(config.steps_per_cal_metrics, 5)
+        self.assertEqual(config.steps_grad_accumulation, 2)
+        self.assertEqual(config._mode, "train_mode")
+        self.assertTrue(config.use_tensorboard)
+        self.assertEqual(config.seed, 42)
+        self.assertEqual(config.bs_train, 4)
+        self.assertEqual(config.nw_train, 2)
+        self.assertEqual(config.loss_weight_dict, {"l1": 0.5})
+    
+    def test_train_pipeline_config_from_dict(self):
+        """Test TrainPipelineConfig creation from dictionary."""
+        config_dict = {
+            "version": "v023",
+            "save_folder": "training_results",
+            "exp_name": "dict_train_test",
+            "epochs": 100,
+            "steps_per_save_imgs": 10,
+            "steps_per_save_ckpt": 10,
+            "steps_per_cal_metrics": 10,
+            "steps_grad_accumulation": 4,
+            "_mode": "train_mode",
+            "use_tensorboard": False,
+            "seed": 123,
+            "bs_train": 8,
+            "nw_train": 4,
+            "optimizer_cfg": {
+                "type": "adam",
+                "lr": 0.001
+            },
+            "loss_weight_dict": {
+                "l1": 1.0,
+                "l2": 0.1
+            }
+        }
+        
+        config = TrainPipelineConfig.from_dict(config_dict)
+        
+        self.assertEqual(config.version, "v023")
+        self.assertEqual(config.save_folder, "training_results")
+        self.assertEqual(config.exp_name, "dict_train_test")
+        self.assertEqual(config.epochs, 100)
+        self.assertEqual(config.steps_per_save_imgs, 10)
+        self.assertEqual(config.steps_per_save_ckpt, 10)
+        self.assertEqual(config.steps_per_cal_metrics, 10)
+        self.assertEqual(config.steps_grad_accumulation, 4)
+        self.assertEqual(config._mode, "train_mode")
+        self.assertFalse(config.use_tensorboard)
+        self.assertEqual(config.seed, 123)
+        self.assertEqual(config.bs_train, 8)
+        self.assertEqual(config.nw_train, 4)
+        self.assertEqual(config.loss_weight_dict, {"l1": 1.0, "l2": 0.1})
+    
+    def test_ensemble_pipeline_config_creation(self):
+        """Test EnsemblePipelineConfig creation."""
+        config = EnsemblePipelineConfig(
+            version="local",
+            save_folder="results",
+            exp_name="ensemble_test",
+            save_metric=True,
+            metric_names=["psnr", "ssim", "lpips"],
+            save_img=True,
+            img_norm=False,
+            bs_test=1,
+            nw_test=0,
+            pin_memory=False,
+            _mode="multi_mode"
+        )
+        
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "ensemble_test")
+        self.assertTrue(config.save_metric)
+        self.assertEqual(config.metric_names, ["psnr", "ssim", "lpips"])
+        self.assertTrue(config.save_img)
+        self.assertFalse(config.img_norm)
+        self.assertEqual(config.bs_test, 1)
+        self.assertEqual(config.nw_test, 0)
+        self.assertFalse(config.pin_memory)
+        self.assertEqual(config._mode, "multi_mode")
+    
+    def test_ensemble_pipeline_config_from_dict(self):
+        """Test EnsemblePipelineConfig creation from dictionary."""
+        config_dict = {
+            "version": "local",
+            "save_folder": "ensemble_results",
+            "exp_name": "dict_ensemble_test",
+            "_mode": "multi_mode",
+            "metric_names": ["psnr", "ssim", "niqe", "brisque"],
+            "save_img": True
+        }
+        
+        config = EnsemblePipelineConfig.from_dict(config_dict)
+        
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "ensemble_results")
+        self.assertEqual(config.exp_name, "dict_ensemble_test")
+        self.assertEqual(config._mode, "multi_mode")
+        self.assertEqual(config.metric_names, ["psnr", "ssim", "niqe", "brisque"])
+        self.assertTrue(config.save_img)
+    
+    def test_load_pipeline_config_base(self):
+        """Test loading base pipeline configuration from file."""
+        # Create a test config file
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "loaded_test",
+            "save_metric": True,
+            "metric_names": ["psnr", "ssim"],
+            "_mode": "single_mode"
+        }
+        
+        config_path = Path(self.temp_dir) / "base_config.yaml"
+        import yaml
+        with open(config_path, 'w') as f:
+            yaml.dump(config_data, f)
+        
+        # Load config
+        config = load_pipeline_config(str(config_path), "base")
+        
+        self.assertIsInstance(config, PipelineConfig)
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "loaded_test")
+    
+    def test_load_pipeline_config_train(self):
+        """Test loading train pipeline configuration from file."""
+        # Create a test config file
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "loaded_train_test",
+            "epochs": 50,
+            "_mode": "train_mode",
+            "use_tensorboard": True
+        }
+        
+        config_path = Path(self.temp_dir) / "train_config.yaml"
+        import yaml
+        with open(config_path, 'w') as f:
+            yaml.dump(config_data, f)
+        
+        # Load config
+        config = load_pipeline_config(str(config_path), "train")
+        
+        self.assertIsInstance(config, TrainPipelineConfig)
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "loaded_train_test")
+        self.assertEqual(config.epochs, 50)
+        self.assertEqual(config._mode, "train_mode")
+        self.assertTrue(config.use_tensorboard)
+    
+    def test_load_pipeline_config_ensemble(self):
+        """Test loading ensemble pipeline configuration from file."""
+        # Create a test config file
+        config_data = {
+            "version": "local",
+            "save_folder": "results",
+            "exp_name": "loaded_ensemble_test",
+            "_mode": "multi_mode",
+            "metric_names": ["psnr", "ssim", "niqe"]
+        }
+        
+        config_path = Path(self.temp_dir) / "ensemble_config.yaml"
+        import yaml
+        with open(config_path, 'w') as f:
+            yaml.dump(config_data, f)
+        
+        # Load config
+        config = load_pipeline_config(str(config_path), "ensemble")
+        
+        self.assertIsInstance(config, EnsemblePipelineConfig)
+        self.assertEqual(config.version, "local")
+        self.assertEqual(config.save_folder, "results")
+        self.assertEqual(config.exp_name, "loaded_ensemble_test")
+        self.assertEqual(config._mode, "multi_mode")
+        self.assertEqual(config.metric_names, ["psnr", "ssim", "niqe"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 🛠️ Dev Bot · TASK-TASK-031

### 📝 实现内容

设计YAML配置文件解析机制，替代硬编码参数，提供统一的配置管理接口。

### 📁 改动文件

| 文件 | 类型 | 改动说明 |
|------|------|---------|
| spikezoo/config/__init__.py | 新增 | 配置模块入口文件 |
| spikezoo/config/config_manager.py | 新增 | 配置文件加载和保存管理器 |
| spikezoo/config/pipeline_configs.py | 新增 | Pipeline配置数据类定义 |
| examples/configs/pipeline_base.yaml | 新增 | 基础Pipeline配置示例 |
| examples/configs/pipeline_train.yaml | 新增 | 训练Pipeline配置示例 |
| examples/configs/pipeline_ensemble.yaml | 新增 | 集成Pipeline配置示例 |
| tests/test_config_manager.py | 新增 | 配置管理器单元测试 |
| tests/test_pipeline_configs.py | 新增 | Pipeline配置类单元测试 |

### ✅ 测试结果

**通过 0 个，失败 0 个**

```
无测试文件
```

### ⚠️ Review 注意事项

- **边界情况**：无
- **依赖变更**：无
- **潜在风险**：无

### 🔗 关联

任务：TASK-031　分支：feature/task-031