### PR TITLE
feat(TASK-002): 统一 infer_from_* 系列方法的参数校验机制

### DIFF
--- a/spikezoo/pipeline/base_pipeline.py
+++ b/spikezoo/pipeline/base_pipeline.py
@@ -22,6 +22,11 @@ import shutil
 from spikingjelly.clock_driven import functional
 import spikezoo as sz
 from .data_preprocessor import DataPreprocessor
+from spikezoo.utils.validation_utils import (
+    validate_infer_from_dataset_params,
+    validate_infer_from_file_params,
+    validate_infer_from_spk_params
+)
 
 
 @dataclass
@@ -109,6 +114,9 @@ class Pipeline:
 
     def infer_from_dataset(self, idx=0):
         """Function I---Save the recoverd image and calculate the metric from the given dataset."""
+        # parameter validation
+        validate_infer_from_dataset_params(idx, len(self.dataset))
+        
         # save folder
         self.logger.info("*********************** infer_from_dataset ***********************")
         save_folder = DataPreprocessor.create_save_folder(
@@ -122,6 +130,9 @@ class Pipeline:
 
     def infer_from_file(self, file_path, height=-1, width=-1, rate=1, img_path=None, remove_head=False):
         """Function II---Save the recoverd image and calculate the metric from the given input file."""
+        # parameter validation
+        validate_infer_from_file_params(file_path, height, width, rate, img_path, remove_head)
+        
         # save folder
         self.logger.info("*********************** infer_from_file ***********************")
         save_folder = DataPreprocessor.create_save_folder(self.save_folder, "file", file_path)
@@ -134,6 +145,9 @@ class Pipeline:
 
     def infer_from_spk(self, spike, rate=1, img=None):
         """Function III---Save the recoverd image and calculate the metric from the given spike stream."""
+        # parameter validation
+        validate_infer_from_spk_params(spike, rate, img)
+        
         # save folder
         self.logger.info("*********************** infer_from_spk ***********************")
         save_folder = DataPreprocessor.create_save_folder(self.save_folder, "spk")

--- a/spikezoo/utils/validation_utils.py
+++ b/spikezoo/utils/validation_utils.py
@@ -1,0 +1,255 @@
+from typing import Any, Optional, Union, List
+import numpy as np
+import torch
+import os
+from pathlib import Path
+
+
+class ParameterValidator:
+    """Parameter validator for infer_from_* series methods."""
+    
+    @staticmethod
+    def validate_dataset_index(idx: int, dataset_length: int) -> None:
+        """
+        Validate dataset index.
+        
+        Args:
+            idx: Dataset index
+            dataset_length: Length of dataset
+            
+        Raises:
+            ValueError: If index is invalid
+            TypeError: If index is not an integer
+        """
+        if not isinstance(idx, int):
+            raise TypeError(f"Dataset index must be an integer, got {type(idx).__name__}")
+        
+        if idx < 0:
+            raise ValueError(f"Dataset index must be non-negative, got {idx}")
+        
+        if idx >= dataset_length:
+            raise ValueError(f"Dataset index {idx} is out of range [0, {dataset_length - 1}]")
+    
+    @staticmethod
+    def validate_file_path(file_path: Union[str, Path]) -> None:
+        """
+        Validate file path.
+        
+        Args:
+            file_path: Path to file
+            
+        Raises:
+            ValueError: If file path is invalid
+            TypeError: If file path is not a string or Path
+            FileNotFoundError: If file does not exist
+        """
+        if not isinstance(file_path, (str, Path)):
+            raise TypeError(f"File path must be a string or Path, got {type(file_path).__name__}")
+        
+        file_path = Path(file_path)
+        
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        
+        if not file_path.is_file():
+            raise ValueError(f"Path is not a file: {file_path}")
+    
+    @staticmethod
+    def validate_dimensions(height: int, width: int) -> None:
+        """
+        Validate height and width dimensions.
+        
+        Args:
+            height: Height dimension
+            width: Width dimension
+            
+        Raises:
+            ValueError: If dimensions are invalid
+            TypeError: If dimensions are not integers
+        """
+        if not isinstance(height, int):
+            raise TypeError(f"Height must be an integer, got {type(height).__name__}")
+        
+        if not isinstance(width, int):
+            raise TypeError(f"Width must be an integer, got {type(width).__name__}")
+        
+        if height <= 0:
+            raise ValueError(f"Height must be positive, got {height}")
+        
+        if width <= 0:
+            raise ValueError(f"Width must be positive, got {width}")
+    
+    @staticmethod
+    def validate_rate(rate: float) -> None:
+        """
+        Validate rate parameter.
+        
+        Args:
+            rate: Rate value
+            
+        Raises:
+            ValueError: If rate is invalid
+            TypeError: If rate is not a number
+        """
+        if not isinstance(rate, (int, float)):
+            raise TypeError(f"Rate must be a number, got {type(rate).__name__}")
+        
+        if rate <= 0:
+            raise ValueError(f"Rate must be positive, got {rate}")
+    
+    @staticmethod
+    def validate_image_path(img_path: Optional[Union[str, Path]]) -> None:
+        """
+        Validate image path.
+        
+        Args:
+            img_path: Path to image file (can be None)
+            
+        Raises:
+            ValueError: If image path is invalid
+            TypeError: If image path is not a string, Path, or None
+            FileNotFoundError: If image file does not exist
+        """
+        if img_path is None:
+            return
+            
+        if not isinstance(img_path, (str, Path)):
+            raise TypeError(f"Image path must be a string, Path, or None, got {type(img_path).__name__}")
+        
+        img_path = Path(img_path)
+        
+        if not img_path.exists():
+            raise FileNotFoundError(f"Image file not found: {img_path}")
+        
+        if not img_path.is_file():
+            raise ValueError(f"Image path is not a file: {img_path}")
+    
+    @staticmethod
+    def validate_spike_data(spike: Union[np.ndarray, torch.Tensor]) -> None:
+        """
+        Validate spike data.
+        
+        Args:
+            spike: Spike data as numpy array or torch tensor
+            
+        Raises:
+            ValueError: If spike data is invalid
+            TypeError: If spike data is not a numpy array or torch tensor
+        """
+        if not isinstance(spike, (np.ndarray, torch.Tensor)):
+            raise TypeError(f"Spike data must be a numpy array or torch tensor, got {type(spike).__name__}")
+        
+        if spike.size == 0:
+            raise ValueError("Spike data cannot be empty")
+        
+        if spike.ndim not in [3, 4]:
+            raise ValueError(f"Spike data must be 3D or 4D, got {spike.ndim}D")
+    
+    @staticmethod
+    def validate_image_data(img: Optional[np.ndarray]) -> None:
+        """
+        Validate image data.
+        
+        Args:
+            img: Image data as numpy array (can be None)
+            
+        Raises:
+            ValueError: If image data is invalid
+            TypeError: If image data is not a numpy array or None
+        """
+        if img is None:
+            return
+            
+        if not isinstance(img, np.ndarray):
+            raise TypeError(f"Image data must be a numpy array or None, got {type(img).__name__}")
+        
+        if img.size == 0:
+            raise ValueError("Image data cannot be empty")
+        
+        if img.ndim not in [2, 3]:
+            raise ValueError(f"Image data must be 2D or 3D, got {img.ndim}D")
+    
+    @staticmethod
+    def validate_remove_head(remove_head: bool) -> None:
+        """
+        Validate remove_head parameter.
+        
+        Args:
+            remove_head: Remove head flag
+            
+        Raises:
+            TypeError: If remove_head is not a boolean
+        """
+        if not isinstance(remove_head, bool):
+            raise TypeError(f"Remove head flag must be a boolean, got {type(remove_head).__name__}")
+
+
+def validate_infer_from_dataset_params(
+    idx: int, 
+    dataset_length: int
+) -> None:
+    """
+    Validate parameters for infer_from_dataset method.
+    
+    Args:
+        idx: Dataset index
+        dataset_length: Length of dataset
+        
+    Raises:
+        ValueError: If parameters are invalid
+        TypeError: If parameters are of wrong type
+    """
+    ParameterValidator.validate_dataset_index(idx, dataset_length)
+
+
+def validate_infer_from_file_params(
+    file_path: Union[str, Path],
+    height: int,
+    width: int,
+    rate: float,
+    img_path: Optional[Union[str, Path]],
+    remove_head: bool
+) -> None:
+    """
+    Validate parameters for infer_from_file method.
+    
+    Args:
+        file_path: Path to spike data file
+        height: Height dimension
+        width: Width dimension
+        rate: Rate value
+        img_path: Path to ground truth image (optional)
+        remove_head: Remove header flag
+        
+    Raises:
+        ValueError: If parameters are invalid
+        TypeError: If parameters are of wrong type
+        FileNotFoundError: If files do not exist
+    """
+    ParameterValidator.validate_file_path(file_path)
+    ParameterValidator.validate_dimensions(height, width)
+    ParameterValidator.validate_rate(rate)
+    ParameterValidator.validate_image_path(img_path)
+    ParameterValidator.validate_remove_head(remove_head)
+
+
+def validate_infer_from_spk_params(
+    spike: Union[np.ndarray, torch.Tensor],
+    rate: float,
+    img: Optional[np.ndarray]
+) -> None:
+    """
+    Validate parameters for infer_from_spk method.
+    
+    Args:
+        spike: Spike data
+        rate: Rate value
+        img: Ground truth image (optional)
+        
+    Raises:
+        ValueError: If parameters are invalid
+        TypeError: If parameters are of wrong type
+    """
+    ParameterValidator.validate_spike_data(spike)
+    ParameterValidator.validate_rate(rate)
+    ParameterValidator.validate_image_data(img)

--- a/tests/test_validation_utils.py
+++ b/tests/test_validation_utils.py
@@ -1,0 +1,293 @@
+import unittest
+import torch
+import numpy as np
+import tempfile
+import os
+from pathlib import Path
+from spikezoo.utils.validation_utils import (
+    ParameterValidator,
+    validate_infer_from_dataset_params,
+    validate_infer_from_file_params,
+    validate_infer_from_spk_params
+)
+
+
+class TestValidationUtils(unittest.TestCase):
+    """Validation utilities unit tests."""
+    
+    def setUp(self):
+        """Test setup."""
+        self.temp_dir = tempfile.mkdtemp()
+        
+        # Create dummy files for testing
+        self.test_file = Path(self.temp_dir) / "test.dat"
+        self.test_file.touch()
+        
+        self.test_img = Path(self.temp_dir) / "test.png"
+        self.test_img.touch()
+    
+    def tearDown(self):
+        """Test cleanup."""
+        # Remove temporary directory
+        for root, dirs, files in os.walk(self.temp_dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self.temp_dir)
+    
+    def test_validate_dataset_index_valid(self):
+        """Test validating valid dataset index."""
+        # Should not raise exception
+        ParameterValidator.validate_dataset_index(0, 10)
+        ParameterValidator.validate_dataset_index(5, 10)
+        ParameterValidator.validate_dataset_index(9, 10)
+    
+    def test_validate_dataset_index_invalid_type(self):
+        """Test validating dataset index with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_dataset_index("0", 10)
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_dataset_index(0.5, 10)
+    
+    def test_validate_dataset_index_negative(self):
+        """Test validating negative dataset index."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_dataset_index(-1, 10)
+    
+    def test_validate_dataset_index_out_of_range(self):
+        """Test validating out of range dataset index."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_dataset_index(10, 10)
+    
+    def test_validate_file_path_valid(self):
+        """Test validating valid file path."""
+        # Should not raise exception
+        ParameterValidator.validate_file_path(self.test_file)
+    
+    def test_validate_file_path_invalid_type(self):
+        """Test validating file path with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_file_path(123)
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_file_path(None)
+    
+    def test_validate_file_path_nonexistent(self):
+        """Test validating nonexistent file path."""
+        with self.assertRaises(FileNotFoundError):
+            ParameterValidator.validate_file_path("nonexistent.txt")
+    
+    def test_validate_file_path_directory(self):
+        """Test validating directory path as file path."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_file_path(self.temp_dir)
+    
+    def test_validate_dimensions_valid(self):
+        """Test validating valid dimensions."""
+        # Should not raise exception
+        ParameterValidator.validate_dimensions(100, 200)
+        ParameterValidator.validate_dimensions(1, 1)
+    
+    def test_validate_dimensions_invalid_type(self):
+        """Test validating dimensions with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_dimensions("100", 200)
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_dimensions(100, "200")
+    
+    def test_validate_dimensions_negative(self):
+        """Test validating negative dimensions."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_dimensions(-1, 200)
+        
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_dimensions(100, -1)
+        
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_dimensions(0, 200)
+    
+    def test_validate_rate_valid(self):
+        """Test validating valid rate."""
+        # Should not raise exception
+        ParameterValidator.validate_rate(1.0)
+        ParameterValidator.validate_rate(0.5)
+        ParameterValidator.validate_rate(100)
+    
+    def test_validate_rate_invalid_type(self):
+        """Test validating rate with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_rate("1.0")
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_rate(None)
+    
+    def test_validate_rate_negative(self):
+        """Test validating negative rate."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_rate(-1.0)
+        
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_rate(0)
+    
+    def test_validate_image_path_valid(self):
+        """Test validating valid image path."""
+        # Should not raise exception
+        ParameterValidator.validate_image_path(self.test_img)
+        ParameterValidator.validate_image_path(None)
+    
+    def test_validate_image_path_invalid_type(self):
+        """Test validating image path with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_image_path(123)
+    
+    def test_validate_image_path_nonexistent(self):
+        """Test validating nonexistent image path."""
+        with self.assertRaises(FileNotFoundError):
+            ParameterValidator.validate_image_path("nonexistent.png")
+    
+    def test_validate_spike_data_valid(self):
+        """Test validating valid spike data."""
+        # Should not raise exception
+        spike_np = np.random.randn(200, 250, 400)
+        ParameterValidator.validate_spike_data(spike_np)
+        
+        spike_torch = torch.randn(1, 200, 250, 400)
+        ParameterValidator.validate_spike_data(spike_torch)
+    
+    def test_validate_spike_data_invalid_type(self):
+        """Test validating spike data with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_spike_data("invalid")
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_spike_data(None)
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_spike_data([1, 2, 3])
+    
+    def test_validate_spike_data_empty(self):
+        """Test validating empty spike data."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_spike_data(np.array([]))
+        
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_spike_data(torch.tensor([]))
+    
+    def test_validate_spike_data_wrong_dimensions(self):
+        """Test validating spike data with wrong dimensions."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_spike_data(np.random.randn(100))
+        
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_spike_data(np.random.randn(100, 200, 300, 400, 500))
+    
+    def test_validate_image_data_valid(self):
+        """Test validating valid image data."""
+        # Should not raise exception
+        img_np = np.random.randint(0, 255, (250, 400), dtype=np.uint8)
+        ParameterValidator.validate_image_data(img_np)
+        
+        ParameterValidator.validate_image_data(None)
+    
+    def test_validate_image_data_invalid_type(self):
+        """Test validating image data with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_image_data("invalid")
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_image_data(torch.tensor([1, 2, 3]))
+    
+    def test_validate_image_data_empty(self):
+        """Test validating empty image data."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_image_data(np.array([]))
+    
+    def test_validate_image_data_wrong_dimensions(self):
+        """Test validating image data with wrong dimensions."""
+        with self.assertRaises(ValueError):
+            ParameterValidator.validate_image_data(np.random.randn(100, 200, 300, 400))
+    
+    def test_validate_remove_head_valid(self):
+        """Test validating valid remove_head parameter."""
+        # Should not raise exception
+        ParameterValidator.validate_remove_head(True)
+        ParameterValidator.validate_remove_head(False)
+    
+    def test_validate_remove_head_invalid_type(self):
+        """Test validating remove_head with invalid type."""
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_remove_head("true")
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_remove_head(1)
+        
+        with self.assertRaises(TypeError):
+            ParameterValidator.validate_remove_head(None)
+    
+    def test_validate_infer_from_dataset_params_valid(self):
+        """Test validating valid infer_from_dataset parameters."""
+        # Should not raise exception
+        validate_infer_from_dataset_params(0, 10)
+        validate_infer_from_dataset_params(5, 10)
+    
+    def test_validate_infer_from_dataset_params_invalid(self):
+        """Test validating invalid infer_from_dataset parameters."""
+        with self.assertRaises(ValueError):
+            validate_infer_from_dataset_params(10, 10)
+        
+        with self.assertRaises(TypeError):
+            validate_infer_from_dataset_params("0", 10)
+    
+    def test_validate_infer_from_file_params_valid(self):
+        """Test validating valid infer_from_file parameters."""
+        # Should not raise exception
+        validate_infer_from_file_params(
+            self.test_file, 250, 400, 1.0, self.test_img, False
+        )
+    
+    def test_validate_infer_from_file_params_invalid(self):
+        """Test validating invalid infer_from_file parameters."""
+        with self.assertRaises(FileNotFoundError):
+            validate_infer_from_file_params(
+                "nonexistent.dat", 250, 400, 1.0, self.test_img, False
+            )
+        
+        with self.assertRaises(TypeError):
+            validate_infer_from_file_params(
+                self.test_file, "250", 400, 1.0, self.test_img, False
+            )
+        
+        with self.assertRaises(ValueError):
+            validate_infer_from_file_params(
+                self.test_file, -250, 400, 1.0, self.test_img, False
+            )
+    
+    def test_validate_infer_from_spk_params_valid(self):
+        """Test validating valid infer_from_spk parameters."""
+        # Should not raise exception
+        spike_np = np.random.randn(200, 250, 400)
+        img_np = np.random.randint(0, 255, (250, 400), dtype=np.uint8)
+        validate_infer_from_spk_params(spike_np, 1.0, img_np)
+        
+        # Test with None image
+        validate_infer_from_spk_params(spike_np, 1.0, None)
+    
+    def test_validate_infer_from_spk_params_invalid(self):
+        """Test validating invalid infer_from_spk parameters."""
+        spike_np = np.random.randn(200, 250, 400)
+        
+        with self.assertRaises(TypeError):
+            validate_infer_from_spk_params("invalid", 1.0, None)
+        
+        with self.assertRaises(ValueError):
+            validate_infer_from_spk_params(np.array([]), 1.0, None)
+        
+        with self.assertRaises(TypeError):
+            validate_infer_from_spk_params(spike_np, "1.0", None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 🛠️ Dev Bot · TASK-TASK-002

### 📝 实现内容

统一 infer_from_* 系列方法的参数校验机制，提供一致的参数验证接口。

### 📁 改动文件

| 文件 | 类型 | 改动说明 |
|------|------|---------|
| spikezoo/utils/validation_utils.py | 新增 | 参数验证工具类 |
| spikezoo/pipeline/base_pipeline.py | 修改 | 集成参数验证机制 |
| tests/test_validation_utils.py | 新增 | 参数验证工具单元测试 |

### ✅ 测试结果

**通过 0 个，失败 0 个**

```
无测试文件
```

### ⚠️ Review 注意事项

- **边界情况**：无
- **依赖变更**：无
- **潜在风险**：无

### 🔗 关联

任务：TASK-002　分支：feature/task-002