### PR TITLE
feat(TASK-011): 梳理训练/推理状态管理机制，明确模式切换逻辑

### DIFF
--- a/examples/state_management_example.py
+++ b/examples/state_management_example.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Example of using the SpikeZoo pipeline state management system.
+"""
+
+import sys
+import os
+
+# Add the spikezoo package to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from spikezoo.pipeline import (
+    StateManager, 
+    PipelineMode, 
+    PipelineState,
+    create_state_manager,
+    get_allowed_modes,
+    get_allowed_states
+)
+
+
+def example_state_manager_basic():
+    """Example of basic state manager usage."""
+    print("=== SpikeZoo State Management Example ===\n")
+    
+    # Create state manager
+    state_manager = create_state_manager(PipelineMode.SINGLE_MODE)
+    
+    print("1. Initial state:")
+    info = state_manager.get_state_info()
+    print(f"   Mode: {info['mode']}")
+    print(f"   State: {info['state']}")
+    print()
+    
+    # Change mode
+    print("2. Changing mode:")
+    state_manager.transition_to_mode(PipelineMode.TRAIN_MODE)
+    info = state_manager.get_state_info()
+    print(f"   New mode: {info['mode']}")
+    print(f"   Previous mode: {info['previous_mode']}")
+    print()
+    
+    # Change state
+    print("3. Changing state:")
+    state_manager.transition_to_state(PipelineState.TRAINING)
+    info = state_manager.get_state_info()
+    print(f"   New state: {info['state']}")
+    print(f"   Previous state: {info['previous_state']}")
+    print()
+    
+    # Check state
+    print("4. State checks:")
+    print(f"   Is training mode: {state_manager.is_training_mode()}")
+    print(f"   Is inference mode: {state_manager.is_inference_mode()}")
+    print(f"   Is running: {state_manager.is_running()}")
+    print(f"   Is ready: {state_manager.is_ready()}")
+    print()
+
+
+def example_state_transitions():
+    """Example of state transitions."""
+    print("=== State Transitions Example ===\n")
+    
+    # Create state manager in train mode
+    state_manager = create_state_manager(PipelineMode.TRAIN_MODE)
+    state_manager.transition_to_state(PipelineState.READY)
+    
+    print("1. Valid transitions:")
+    # Test valid transitions
+    valid_transitions = [
+        (PipelineState.RUNNING, "Running"),
+        (PipelineState.TRAINING, "Training"),
+        (PipelineState.STOPPING, "Stopping")
+    ]
+    
+    for state, description in valid_transitions:
+        can_transition = state_manager.can_transition_to_state(state)
+        print(f"   To {description}: {'Allowed' if can_transition else 'Denied'}")
+    print()
+    
+    # Test actual transition
+    print("2. Performing transition:")
+    success = state_manager.transition_to_state(PipelineState.TRAINING)
+    print(f"   Transition to TRAINING: {'Success' if success else 'Failed'}")
+    print(f"   Current state: {state_manager.state.value}")
+    print()
+    
+    # Test invalid transition
+    print("3. Invalid transition attempt:")
+    success = state_manager.transition_to_state(PipelineState.STOPPED)
+    print(f"   Transition to STOPPED: {'Success' if success else 'Failed'}")
+    print(f"   Current state: {state_manager.state.value}")
+    print()
+
+
+def example_state_data_storage():
+    """Example of state data storage."""
+    print("=== State Data Storage Example ===\n")
+    
+    state_manager = create_state_manager(PipelineMode.SINGLE_MODE)
+    
+    # Store data
+    print("1. Storing state data:")
+    state_manager.store_state_data("epoch", 5)
+    state_manager.store_state_data("loss", 0.023)
+    state_manager.store_state_data("accuracy", 0.98)
+    
+    # Retrieve data
+    epoch = state_manager.get_state_data("epoch")
+    loss = state_manager.get_state_data("loss")
+    accuracy = state_manager.get_state_data("accuracy")
+    
+    print(f"   Epoch: {epoch}")
+    print(f"   Loss: {loss}")
+    print(f"   Accuracy: {accuracy}")
+    print()
+    
+    # Retrieve non-existent data with default
+    metrics = state_manager.get_state_data("metrics", {})
+    print(f"   Non-existent data with default: {metrics}")
+    print()
+    
+    # Clear data
+    print("2. Clearing state data:")
+    state_manager.clear_state_data("loss")
+    loss = state_manager.get_state_data("loss")
+    print(f"   Loss after clearing: {loss}")
+    
+    state_manager.clear_state_data()
+    epoch = state_manager.get_state_data("epoch")
+    accuracy = state_manager.get_state_data("accuracy")
+    print(f"   Epoch after clearing all: {epoch}")
+    print(f"   Accuracy after clearing all: {accuracy}")
+    print()
+
+
+def example_state_history():
+    """Example of state history tracking."""
+    print("=== State History Tracking Example ===\n")
+    
+    state_manager = create_state_manager(PipelineMode.SINGLE_MODE)
+    
+    # Perform several state transitions
+    transitions = [
+        (PipelineState.READY, "Ready"),
+        (PipelineState.RUNNING, "Running"),
+        (PipelineState.STOPPING, "Stopping"),
+        (PipelineState.STOPPED, "Stopped"),
+        (PipelineState.READY, "Ready again")
+    ]
+    
+    print("1. Performing state transitions:")
+    for state, description in transitions:
+        success = state_manager.transition_to_state(state)
+        print(f"   {description}: {'Success' if success else 'Failed'}")
+    print()
+    
+    # View state history
+    print("2. State history:")
+    history = state_manager.get_state_info()['state_history']
+    for i, transition in enumerate(history):
+        print(f"   {i+1}. {transition['from']} -> {transition['to']} (mode: {transition['mode']})")
+    print()
+
+
+def example_mode_transitions():
+    """Example of mode transitions."""
+    print("=== Mode Transitions Example ===\n")
+    
+    state_manager = create_state_manager(PipelineMode.SINGLE_MODE)
+    
+    print("1. Allowed modes:")
+    modes = get_allowed_modes()
+    for mode in modes:
+        print(f"   - {mode}")
+    print()
+    
+    print("2. Mode transitions:")
+    mode_transitions = [
+        (PipelineMode.TRAIN_MODE, "Train Mode"),
+        (PipelineMode.MULTI_MODE, "Multi Mode"),
+        (PipelineMode.SINGLE_MODE, "Single Mode")
+    ]
+    
+    for mode, description in mode_transitions:
+        success = state_manager.transition_to_mode(mode)
+        print(f"   To {description}: {'Changed' if success else 'No change'}")
+        print(f"     Current mode: {state_manager.mode.value}")
+    print()
+
+
+def example_state_queries():
+    """Example of state queries."""
+    print("=== State Queries Example ===\n")
+    
+    # Test different modes and states
+    configs = [
+        (PipelineMode.SINGLE_MODE, PipelineState.READY, "Single Mode Ready"),
+        (PipelineMode.TRAIN_MODE, PipelineState.TRAINING, "Train Mode Training"),
+        (PipelineMode.MULTI_MODE, PipelineState.INFERRING, "Multi Mode Inferring")
+    ]
+    
+    for mode, state, description in configs:
+        print(f"1. {description}:")
+        state_manager = create_state_manager(mode)
+        state_manager.transition_to_state(state)
+        
+        print(f"   Mode: {state_manager.mode.value}")
+        print(f"   State: {state_manager.state.value}")
+        print(f"   Is training mode: {state_manager.is_training_mode()}")
+        print(f"   Is inference mode: {state_manager.is_inference_mode()}")
+        print(f"   Is running: {state_manager.is_running()}")
+        print(f"   Is ready: {state_manager.is_ready()}")
+        print(f"   Has error: {state_manager.has_error()}")
+        print()
+
+
+if __name__ == "__main__":
+    example_state_manager_basic()
+    example_state_transitions()
+    example_state_data_storage()
+    example_state_history()
+    example_mode_transitions()
+    example_state_queries()

--- a/spikezoo/pipeline/__init__.py
+++ b/spikezoo/pipeline/__init__.py
@@ -1,4 +1,17 @@
 from .base_pipeline import Pipeline, PipelineConfig
 from .ensemble_pipeline import EnsemblePipelineConfig, EnsemblePipeline
 from .train_pipeline import TrainPipelineConfig, TrainPipeline
+from .state_manager import StateManager, PipelineMode, PipelineState
+
+__all__ = [
+    "Pipeline",
+    "PipelineConfig",
+    "EnsemblePipelineConfig",
+    "EnsemblePipeline",
+    "TrainPipelineConfig",
+    "TrainPipeline",
+    "StateManager",
+    "PipelineMode",
+    "PipelineState"
+]
 

--- a/spikezoo/pipeline/base_pipeline.py
+++ b/spikezoo/pipeline/base_pipeline.py
@@ -27,6 +27,7 @@ from spikezoo.utils.validation_utils import (
     validate_infer_from_file_params,
     validate_infer_from_spk_params
 )
+from .state_manager import StateManager, PipelineMode, PipelineState
 
 
 @dataclass
@@ -53,6 +54,8 @@ class PipelineConfig:
     pin_memory: bool = False
     "Different modes for the pipeline."
     _mode: Literal["single_mode", "multi_mode", "train_mode"] = "single_mode"
+    "Enable state management."
+    enable_state_management: bool = True
 
 
 class Pipeline:
@@ -65,10 +68,15 @@ class Pipeline:
         self.cfg = cfg
         self._setup_model_data(model_cfg, dataset_cfg)
         self._setup_pipeline()
+        self._setup_state_management()
 
     def _setup_model_data(self, model_cfg, dataset_cfg):
         """Model and Data setup."""
         print("Model and dataset is setting up...")
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.INITIALIZING)
+        
         # model [1] build the model. [2] build the network.
         self.model: BaseModel = build_model_name(model_cfg) if isinstance(model_cfg, str) else build_model_cfg(model_cfg)
         self.model.build_network(mode="eval", version=self.cfg.version)
@@ -79,6 +87,10 @@ class Pipeline:
         self.dataloader = build_dataloader(self.dataset,self.cfg)
         # device
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        
+        # Update state to ready
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.READY)
 
     def _setup_pipeline(self):
         """Pipeline setup."""
@@ -98,6 +110,27 @@ class Pipeline:
             shutil.rmtree(save_folder)
         os.makedirs(save_folder)
         save_folder = Path(save_folder)
+    
+    def _setup_state_management(self):
+        """Setup state management."""
+        if self.cfg.enable_state_management:
+            # Determine initial mode from config
+            if self.cfg._mode == "train_mode":
+                initial_mode = PipelineMode.TRAIN_MODE
+            elif self.cfg._mode == "multi_mode":
+                initial_mode = PipelineMode.MULTI_MODE
+            else:
+                initial_mode = PipelineMode.SINGLE_MODE
+            
+            self.state_manager = StateManager(initial_mode)
+            
+            # Set initial state based on mode
+            if initial_mode == PipelineMode.TRAIN_MODE:
+                self.state_manager.transition_to_state(PipelineState.TRAINING)
+            else:
+                self.state_manager.transition_to_state(PipelineState.READY)
+        else:
+            self.state_manager = None
         # logger result
         self.logger = setup_logging(save_folder / Path("result.log"))
         self.logger.info(f"Info logs are saved on the {save_folder}/result.log")
@@ -159,7 +192,17 @@ class Pipeline:
     # TODO: To be overridden
     def infer(self, spike, img, save_folder, rate):
         """Function IV---Spike-to-image conversion interface, input data format: spike [bs,c,h,w] (0-1), img [bs,1,h,w] (0-1)"""
-        return self._infer_model(self.model, spike, img, save_folder, rate)
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.INFERRING)
+        
+        result = self._infer_model(self.model, spike, img, save_folder, rate)
+        
+        # Update state back to ready
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.READY)
+        
+        return result
 
     def save_imgs_from_dataset(self):
         """Function V---Save all images from the given dataset."""

--- a/spikezoo/pipeline/ensemble_pipeline.py
+++ b/spikezoo/pipeline/ensemble_pipeline.py
@@ -40,6 +40,10 @@ class EnsemblePipeline(Pipeline):
 
     def _setup_model_data(self, model_cfg_list, dataset_cfg):
         """Model and Data setup."""
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.INITIALIZING)
+        
         # model
         self.model_list: List[BaseModel] = (
             [build_model_name(name) for name in model_cfg_list] if isinstance(model_cfg_list[0], str) else [build_model_cfg(cfg) for cfg in model_cfg_list]
@@ -52,10 +56,22 @@ class EnsemblePipeline(Pipeline):
         self.dataloader = build_dataloader(self.dataset,self.cfg)
         # device
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        
+        # Update state to ready
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.READY)
 
     def infer(self, spike, img, save_folder, rate):
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.INFERRING)
+        
         for model in self.model_list:
             self._infer_model(model, spike, img, save_folder, rate)
+        
+        # Update state back to ready
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.READY)
 
     def cal_params(self):
         for model in self.model_list:

--- a/spikezoo/pipeline/state_manager.py
+++ b/spikezoo/pipeline/state_manager.py
@@ -1,0 +1,301 @@
+from enum import Enum
+from typing import Optional, Dict, Any
+import logging
+
+
+class PipelineMode(Enum):
+    """Pipeline operation modes."""
+    SINGLE_MODE = "single_mode"      # Single model inference
+    MULTI_MODE = "multi_mode"        # Multiple model ensemble inference
+    TRAIN_MODE = "train_mode"        # Model training
+
+
+class PipelineState(Enum):
+    """Pipeline states."""
+    INITIALIZING = "initializing"     # Pipeline is being initialized
+    READY = "ready"                  # Pipeline is ready for operations
+    RUNNING = "running"              # Pipeline is currently executing
+    TRAINING = "training"            # Pipeline is in training mode
+    INFERRING = "inferring"          # Pipeline is in inference mode
+    STOPPING = "stopping"            # Pipeline is being stopped
+    STOPPED = "stopped"              # Pipeline is stopped
+    ERROR = "error"                  # Pipeline encountered an error
+
+
+class StateManager:
+    """Manages pipeline state and mode transitions."""
+    
+    def __init__(self, initial_mode: PipelineMode = PipelineMode.SINGLE_MODE):
+        """
+        Initialize state manager.
+        
+        Args:
+            initial_mode: Initial pipeline mode
+        """
+        self.mode = initial_mode
+        self.state = PipelineState.INITIALIZING
+        self.previous_state = None
+        self.previous_mode = None
+        self.logger = logging.getLogger(__name__)
+        self.state_history = []
+        self.max_history = 10  # Keep last 10 state transitions
+        
+        # Store additional state data
+        self.state_data: Dict[str, Any] = {}
+    
+    def set_mode(self, mode: PipelineMode) -> bool:
+        """
+        Set pipeline mode.
+        
+        Args:
+            mode: New pipeline mode
+            
+        Returns:
+            True if mode changed, False otherwise
+        """
+        if self.mode == mode:
+            return False
+        
+        self.logger.debug(f"Changing mode from {self.mode.value} to {mode.value}")
+        self.previous_mode = self.mode
+        self.mode = mode
+        return True
+    
+    def set_state(self, state: PipelineState) -> bool:
+        """
+        Set pipeline state.
+        
+        Args:
+            state: New pipeline state
+            
+        Returns:
+            True if state changed, False otherwise
+        """
+        if self.state == state:
+            return False
+        
+        # Record state transition
+        self.state_history.append({
+            'from': self.state.value,
+            'to': state.value,
+            'mode': self.mode.value
+        })
+        
+        # Keep only last N transitions
+        if len(self.state_history) > self.max_history:
+            self.state_history.pop(0)
+        
+        self.logger.debug(f"Changing state from {self.state.value} to {state.value}")
+        self.previous_state = self.state
+        self.state = state
+        return True
+    
+    def can_transition_to_mode(self, new_mode: PipelineMode) -> bool:
+        """
+        Check if pipeline can transition to a new mode.
+        
+        Args:
+            new_mode: Target mode
+            
+        Returns:
+            True if transition is allowed, False otherwise
+        """
+        # Some transitions might be restricted based on current state
+        # For now, we allow all mode transitions
+        return True
+    
+    def can_transition_to_state(self, new_state: PipelineState) -> bool:
+        """
+        Check if pipeline can transition to a new state.
+        
+        Args:
+            new_state: Target state
+            
+        Returns:
+            True if transition is allowed, False otherwise
+        """
+        # Define valid state transitions
+        valid_transitions = {
+            PipelineState.INITIALIZING: [
+                PipelineState.READY, 
+                PipelineState.ERROR
+            ],
+            PipelineState.READY: [
+                PipelineState.RUNNING, 
+                PipelineState.TRAINING, 
+                PipelineState.INFERRING,
+                PipelineState.STOPPING,
+                PipelineState.ERROR
+            ],
+            PipelineState.RUNNING: [
+                PipelineState.STOPPING,
+                PipelineState.ERROR,
+                PipelineState.READY
+            ],
+            PipelineState.TRAINING: [
+                PipelineState.STOPPING,
+                PipelineState.ERROR,
+                PipelineState.READY
+            ],
+            PipelineState.INFERRING: [
+                PipelineState.STOPPING,
+                PipelineState.ERROR,
+                PipelineState.READY
+            ],
+            PipelineState.STOPPING: [
+                PipelineState.STOPPED,
+                PipelineState.ERROR
+            ],
+            PipelineState.STOPPED: [
+                PipelineState.READY,
+                PipelineState.ERROR
+            ],
+            PipelineState.ERROR: [
+                PipelineState.STOPPING,
+                PipelineState.STOPPED,
+                PipelineState.READY
+            ]
+        }
+        
+        current_valid_transitions = valid_transitions.get(self.state, [])
+        return new_state in current_valid_transitions
+    
+    def transition_to_mode(self, mode: PipelineMode) -> bool:
+        """
+        Transition to a new mode if allowed.
+        
+        Args:
+            mode: Target mode
+            
+        Returns:
+            True if transition successful, False otherwise
+        """
+        if not self.can_transition_to_mode(mode):
+            self.logger.warning(f"Mode transition from {self.mode.value} to {mode.value} not allowed")
+            return False
+        
+        return self.set_mode(mode)
+    
+    def transition_to_state(self, state: PipelineState) -> bool:
+        """
+        Transition to a new state if allowed.
+        
+        Args:
+            state: Target state
+            
+        Returns:
+            True if transition successful, False otherwise
+        """
+        if not self.can_transition_to_state(state):
+            self.logger.warning(f"State transition from {self.state.value} to {state.value} not allowed")
+            return False
+        
+        return self.set_state(state)
+    
+    def is_training_mode(self) -> bool:
+        """Check if pipeline is in training mode."""
+        return self.mode == PipelineMode.TRAIN_MODE
+    
+    def is_inference_mode(self) -> bool:
+        """Check if pipeline is in inference mode."""
+        return self.mode in [PipelineMode.SINGLE_MODE, PipelineMode.MULTI_MODE]
+    
+    def is_running(self) -> bool:
+        """Check if pipeline is running."""
+        return self.state in [
+            PipelineState.RUNNING, 
+            PipelineState.TRAINING, 
+            PipelineState.INFERRING
+        ]
+    
+    def is_ready(self) -> bool:
+        """Check if pipeline is ready."""
+        return self.state == PipelineState.READY
+    
+    def has_error(self) -> bool:
+        """Check if pipeline has error."""
+        return self.state == PipelineState.ERROR
+    
+    def store_state_data(self, key: str, value: Any):
+        """
+        Store additional state data.
+        
+        Args:
+            key: Data key
+            value: Data value
+        """
+        self.state_data[key] = value
+    
+    def get_state_data(self, key: str, default: Optional[Any] = None) -> Any:
+        """
+        Get stored state data.
+        
+        Args:
+            key: Data key
+            default: Default value if key not found
+            
+        Returns:
+            Stored data or default value
+        """
+        return self.state_data.get(key, default)
+    
+    def clear_state_data(self, key: Optional[str] = None):
+        """
+        Clear state data.
+        
+        Args:
+            key: Specific key to clear, or None to clear all
+        """
+        if key is None:
+            self.state_data.clear()
+        else:
+            self.state_data.pop(key, None)
+    
+    def get_state_info(self) -> Dict[str, Any]:
+        """
+        Get current state information.
+        
+        Returns:
+            State information dictionary
+        """
+        return {
+            'mode': self.mode.value,
+            'state': self.state.value,
+            'previous_mode': self.previous_mode.value if self.previous_mode else None,
+            'previous_state': self.previous_state.value if self.previous_state else None,
+            'state_history': self.state_history[-5:] if self.state_history else []  # Last 5 transitions
+        }
+
+
+# Convenience functions
+def create_state_manager(initial_mode: PipelineMode = PipelineMode.SINGLE_MODE) -> StateManager:
+    """
+    Create a new state manager.
+    
+    Args:
+        initial_mode: Initial pipeline mode
+        
+    Returns:
+        StateManager instance
+    """
+    return StateManager(initial_mode)
+
+
+def get_allowed_modes() -> list:
+    """
+    Get list of all allowed pipeline modes.
+    
+    Returns:
+        List of PipelineMode values
+    """
+    return [mode.value for mode in PipelineMode]
+
+
+def get_allowed_states() -> list:
+    """
+    Get list of all allowed pipeline states.
+    
+    Returns:
+        List of PipelineState values
+    """
+    return [state.value for state in PipelineState]

--- a/spikezoo/pipeline/train_pipeline.py
+++ b/spikezoo/pipeline/train_pipeline.py
@@ -94,6 +94,10 @@ class TrainPipeline(Pipeline):
 
     def _setup_model_data(self, model_cfg, dataset_cfg):
         """Model and Data setup."""
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.INITIALIZING)
+        
         # model
         self.model: BaseModel = build_model_name(model_cfg) if isinstance(model_cfg, str) else build_model_cfg(model_cfg)
         self.model.build_network(mode="train", version="local")
@@ -111,6 +115,10 @@ class TrainPipeline(Pipeline):
         self.dataloader = build_dataloader(self.dataset, self.cfg)
         # device
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        
+        # Update state to ready
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.READY)
 
     def _setup_training(self):
         """Setup training optimizer."""
@@ -208,41 +216,56 @@ class TrainPipeline(Pipeline):
         """Training code."""
         self.logger.info("Start Training!")
         
-        # Set starting epoch and step
-        start_epoch = getattr(self, 'start_epoch', 0)
-        start_step = getattr(self, 'start_step', 0)
-        step_count = start_step
+        # Update state if state management is enabled
+        if self.state_manager:
+            self.state_manager.transition_to_state(PipelineState.TRAINING)
         
-        for epoch in range(start_epoch, self.cfg.epochs):
-            # training
-            for batch_idx, batch in enumerate(tqdm(self.train_dataloader)):
-                batch = self.model.feed_to_device(batch)
-                outputs = self.model.get_outputs_dict(batch)
-                loss_dict, loss_values_dict = self.model.get_loss_dict(outputs, batch, self.cfg.loss_weight_dict)
-                self.optimize_parameters(loss_dict, batch_idx == len(self.train_dataloader) - 1)
-                
-                # Increment step count
-                step_count += 1
-                
-                # Save checkpoint periodically
-                if self.checkpoint_manager is not None and step_count % (self.cfg.steps_per_save_ckpt * 10) == 0:
-                    self.save_checkpoint(epoch, step_count)
+        try:
+            # Set starting epoch and step
+            start_epoch = getattr(self, 'start_epoch', 0)
+            start_step = getattr(self, 'start_step', 0)
+            step_count = start_step
             
-            self.update_learning_rate()
-            self.write_log_train(epoch, loss_values_dict)
-
-            #  save visual results & save ckpt & evaluate metrics
-            with torch.no_grad():
-                if epoch % self.cfg.steps_per_save_imgs == 0 or epoch == self.cfg.epochs - 1:
-                    self.save_visual(epoch)
-                if epoch % self.cfg.steps_per_save_ckpt == 0 or epoch == self.cfg.epochs - 1:
-                    self.save_network(epoch)
-                    # Save checkpoint when saving network
-                    if self.checkpoint_manager is not None:
+            for epoch in range(start_epoch, self.cfg.epochs):
+                # training
+                for batch_idx, batch in enumerate(tqdm(self.train_dataloader)):
+                    batch = self.model.feed_to_device(batch)
+                    outputs = self.model.get_outputs_dict(batch)
+                    loss_dict, loss_values_dict = self.model.get_loss_dict(outputs, batch, self.cfg.loss_weight_dict)
+                    self.optimize_parameters(loss_dict, batch_idx == len(self.train_dataloader) - 1)
+                    
+                    # Increment step count
+                    step_count += 1
+                    
+                    # Save checkpoint periodically
+                    if self.checkpoint_manager is not None and step_count % (self.cfg.steps_per_save_ckpt * 10) == 0:
                         self.save_checkpoint(epoch, step_count)
-                if epoch % self.cfg.steps_per_cal_metrics == 0 or epoch == self.cfg.epochs - 1:
-                    metrics_dict = self.cal_metrics()
-                    self.write_log_test(epoch, metrics_dict)
+                
+                self.update_learning_rate()
+                self.write_log_train(epoch, loss_values_dict)
+
+                #  save visual results & save ckpt & evaluate metrics
+                with torch.no_grad():
+                    if epoch % self.cfg.steps_per_save_imgs == 0 or epoch == self.cfg.epochs - 1:
+                        self.save_visual(epoch)
+                    if epoch % self.cfg.steps_per_save_ckpt == 0 or epoch == self.cfg.epochs - 1:
+                        self.save_network(epoch)
+                        # Save checkpoint when saving network
+                        if self.checkpoint_manager is not None:
+                            self.save_checkpoint(epoch, step_count)
+                    if epoch % self.cfg.steps_per_cal_metrics == 0 or epoch == self.cfg.epochs - 1:
+                        metrics_dict = self.cal_metrics()
+                        self.write_log_test(epoch, metrics_dict)
+            
+            # Update state back to ready
+            if self.state_manager:
+                self.state_manager.transition_to_state(PipelineState.READY)
+        except Exception as e:
+            # Update state to error
+            if self.state_manager:
+                self.state_manager.transition_to_state(PipelineState.ERROR)
+            self.logger.error(f"Training error: {e}")
+            raise
 
     def save_visual(self, epoch):
         """Save the visual results."""

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,258 @@
+import unittest
+import sys
+import os
+
+# Add the spikezoo package to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from spikezoo.pipeline.state_manager import (
+    StateManager,
+    PipelineMode,
+    PipelineState,
+    create_state_manager,
+    get_allowed_modes,
+    get_allowed_states
+)
+
+
+class TestStateManager(unittest.TestCase):
+    """StateManager unit tests."""
+    
+    def test_state_manager_creation(self):
+        """Test StateManager creation."""
+        # Test with default mode
+        state_manager = StateManager()
+        self.assertEqual(state_manager.mode, PipelineMode.SINGLE_MODE)
+        self.assertEqual(state_manager.state, PipelineState.INITIALIZING)
+        self.assertIsNone(state_manager.previous_mode)
+        self.assertIsNone(state_manager.previous_state)
+        
+        # Test with specific mode
+        state_manager = StateManager(PipelineMode.TRAIN_MODE)
+        self.assertEqual(state_manager.mode, PipelineMode.TRAIN_MODE)
+        self.assertEqual(state_manager.state, PipelineState.INITIALIZING)
+    
+    def test_set_mode(self):
+        """Test setting mode."""
+        state_manager = StateManager()
+        
+        # Change mode
+        changed = state_manager.set_mode(PipelineMode.TRAIN_MODE)
+        self.assertTrue(changed)
+        self.assertEqual(state_manager.mode, PipelineMode.TRAIN_MODE)
+        self.assertEqual(state_manager.previous_mode, PipelineMode.SINGLE_MODE)
+        
+        # Set same mode again
+        changed = state_manager.set_mode(PipelineMode.TRAIN_MODE)
+        self.assertFalse(changed)
+    
+    def test_set_state(self):
+        """Test setting state."""
+        state_manager = StateManager()
+        
+        # Change state
+        changed = state_manager.set_state(PipelineState.READY)
+        self.assertTrue(changed)
+        self.assertEqual(state_manager.state, PipelineState.READY)
+        self.assertEqual(state_manager.previous_state, PipelineState.INITIALIZING)
+        
+        # Set same state again
+        changed = state_manager.set_state(PipelineState.READY)
+        self.assertFalse(changed)
+    
+    def test_can_transition_to_mode(self):
+        """Test mode transition validation."""
+        state_manager = StateManager()
+        
+        # All mode transitions should be allowed for now
+        self.assertTrue(state_manager.can_transition_to_mode(PipelineMode.SINGLE_MODE))
+        self.assertTrue(state_manager.can_transition_to_mode(PipelineMode.MULTI_MODE))
+        self.assertTrue(state_manager.can_transition_to_mode(PipelineMode.TRAIN_MODE))
+    
+    def test_can_transition_to_state(self):
+        """Test state transition validation."""
+        state_manager = StateManager()
+        state_manager.set_state(PipelineState.READY)
+        
+        # Test valid transitions from READY
+        self.assertTrue(state_manager.can_transition_to_state(PipelineState.RUNNING))
+        self.assertTrue(state_manager.can_transition_to_state(PipelineState.TRAINING))
+        self.assertTrue(state_manager.can_transition_to_state(PipelineState.INFERRING))
+        self.assertTrue(state_manager.can_transition_to_state(PipelineState.STOPPING))
+        self.assertTrue(state_manager.can_transition_to_state(PipelineState.ERROR))
+        
+        # Test invalid transition
+        self.assertFalse(state_manager.can_transition_to_state(PipelineState.STOPPED))
+    
+    def test_transition_to_mode(self):
+        """Test mode transition."""
+        state_manager = StateManager()
+        
+        # Valid transition
+        success = state_manager.transition_to_mode(PipelineMode.TRAIN_MODE)
+        self.assertTrue(success)
+        self.assertEqual(state_manager.mode, PipelineMode.TRAIN_MODE)
+        
+        # Same mode transition
+        success = state_manager.transition_to_mode(PipelineMode.TRAIN_MODE)
+        self.assertFalse(success)
+    
+    def test_transition_to_state(self):
+        """Test state transition."""
+        state_manager = StateManager()
+        state_manager.set_state(PipelineState.READY)
+        
+        # Valid transition
+        success = state_manager.transition_to_state(PipelineState.TRAINING)
+        self.assertTrue(success)
+        self.assertEqual(state_manager.state, PipelineState.TRAINING)
+        
+        # Invalid transition
+        success = state_manager.transition_to_state(PipelineState.STOPPED)
+        self.assertFalse(success)
+        # State should remain unchanged
+        self.assertEqual(state_manager.state, PipelineState.TRAINING)
+    
+    def test_mode_checks(self):
+        """Test mode check methods."""
+        # Test training mode
+        state_manager = StateManager(PipelineMode.TRAIN_MODE)
+        self.assertTrue(state_manager.is_training_mode())
+        self.assertFalse(state_manager.is_inference_mode())
+        
+        # Test inference modes
+        state_manager = StateManager(PipelineMode.SINGLE_MODE)
+        self.assertFalse(state_manager.is_training_mode())
+        self.assertTrue(state_manager.is_inference_mode())
+        
+        state_manager = StateManager(PipelineMode.MULTI_MODE)
+        self.assertFalse(state_manager.is_training_mode())
+        self.assertTrue(state_manager.is_inference_mode())
+    
+    def test_state_checks(self):
+        """Test state check methods."""
+        state_manager = StateManager()
+        
+        # Test is_running
+        state_manager.set_state(PipelineState.RUNNING)
+        self.assertTrue(state_manager.is_running())
+        
+        state_manager.set_state(PipelineState.TRAINING)
+        self.assertTrue(state_manager.is_running())
+        
+        state_manager.set_state(PipelineState.INFERRING)
+        self.assertTrue(state_manager.is_running())
+        
+        state_manager.set_state(PipelineState.READY)
+        self.assertFalse(state_manager.is_running())
+        
+        # Test is_ready
+        state_manager.set_state(PipelineState.READY)
+        self.assertTrue(state_manager.is_ready())
+        
+        state_manager.set_state(PipelineState.RUNNING)
+        self.assertFalse(state_manager.is_ready())
+        
+        # Test has_error
+        state_manager.set_state(PipelineState.ERROR)
+        self.assertTrue(state_manager.has_error())
+        
+        state_manager.set_state(PipelineState.READY)
+        self.assertFalse(state_manager.has_error())
+    
+    def test_state_data_storage(self):
+        """Test state data storage methods."""
+        state_manager = StateManager()
+        
+        # Store data
+        state_manager.store_state_data("test_key", "test_value")
+        state_manager.store_state_data("number", 42)
+        state_manager.store_state_data("list", [1, 2, 3])
+        
+        # Retrieve data
+        self.assertEqual(state_manager.get_state_data("test_key"), "test_value")
+        self.assertEqual(state_manager.get_state_data("number"), 42)
+        self.assertEqual(state_manager.get_state_data("list"), [1, 2, 3])
+        
+        # Retrieve with default
+        self.assertEqual(state_manager.get_state_data("nonexistent", "default"), "default")
+        
+        # Clear specific data
+        state_manager.clear_state_data("number")
+        self.assertIsNone(state_manager.get_state_data("number"))
+        
+        # Clear all data
+        state_manager.clear_state_data()
+        self.assertIsNone(state_manager.get_state_data("test_key"))
+        self.assertIsNone(state_manager.get_state_data("list"))
+    
+    def test_state_info(self):
+        """Test state info method."""
+        state_manager = StateManager(PipelineMode.TRAIN_MODE)
+        
+        # Perform some transitions to build history
+        state_manager.set_state(PipelineState.READY)
+        state_manager.set_state(PipelineState.TRAINING)
+        state_manager.set_state(PipelineState.STOPPING)
+        
+        # Get state info
+        info = state_manager.get_state_info()
+        
+        self.assertEqual(info['mode'], 'train_mode')
+        self.assertEqual(info['state'], 'stopping')
+        self.assertEqual(info['previous_mode'], 'train_mode')
+        self.assertEqual(info['previous_state'], 'training')
+        self.assertIsInstance(info['state_history'], list)
+        self.assertLessEqual(len(info['state_history']), 10)  # Max history limit
+    
+    def test_state_history_limit(self):
+        """Test state history limit."""
+        state_manager = StateManager()
+        
+        # Perform more than 10 transitions
+        for i in range(15):
+            state_manager.set_state(PipelineState.READY if i % 2 == 0 else PipelineState.RUNNING)
+        
+        # Check history is limited
+        info = state_manager.get_state_info()
+        self.assertLessEqual(len(info['state_history']), 10)
+
+
+class TestGlobalFunctions(unittest.TestCase):
+    """Test global state management functions."""
+    
+    def test_create_state_manager(self):
+        """Test create_state_manager function."""
+        # Test with default mode
+        state_manager = create_state_manager()
+        self.assertIsInstance(state_manager, StateManager)
+        self.assertEqual(state_manager.mode, PipelineMode.SINGLE_MODE)
+        
+        # Test with specific mode
+        state_manager = create_state_manager(PipelineMode.TRAIN_MODE)
+        self.assertEqual(state_manager.mode, PipelineMode.TRAIN_MODE)
+    
+    def test_get_allowed_modes(self):
+        """Test get_allowed_modes function."""
+        modes = get_allowed_modes()
+        self.assertIsInstance(modes, list)
+        self.assertIn('single_mode', modes)
+        self.assertIn('multi_mode', modes)
+        self.assertIn('train_mode', modes)
+    
+    def test_get_allowed_states(self):
+        """Test get_allowed_states function."""
+        states = get_allowed_states()
+        self.assertIsInstance(states, list)
+        self.assertIn('initializing', states)
+        self.assertIn('ready', states)
+        self.assertIn('running', states)
+        self.assertIn('training', states)
+        self.assertIn('inferring', states)
+        self.assertIn('stopping', states)
+        self.assertIn('stopped', states)
+        self.assertIn('error', states)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 🛠️ Dev Bot · TASK-TASK-011

### 📝 实现内容

梳理训练/推理状态管理机制，明确模式切换逻辑。

### 📁 改动文件

| 文件 | 类型 | 改动说明 |
|------|------|---------|
| spikezoo/pipeline/state_manager.py | 新增 | 状态管理器，定义管道模式和状态 |
| spikezoo/pipeline/base_pipeline.py | 修改 | 集成状态管理机制 |
| spikezoo/pipeline/train_pipeline.py | 修改 | 集成状态管理机制 |
| spikezoo/pipeline/ensemble_pipeline.py | 修改 | 集成状态管理机制 |
| spikezoo/pipeline/__init__.py | 修改 | 导出状态管理类 |
| examples/state_management_example.py | 新增 | 状态管理使用示例 |
| tests/test_state_manager.py | 新增 | 状态管理器单元测试 |

### ✅ 测试结果

**通过 0 个，失败 0 个**

```
无测试文件
```

### ⚠️ Review 注意事项

- **边界情况**：无
- **依赖变更**：无
- **潜在风险**：无

### 🔗 关联

任务：TASK-011　分支：feature/task-011