### PR TITLE
feat(TASK-023): 设计管道组件注册机制，提高模块化程度

### DIFF
--- a/examples/component_registration_example.py
+++ b/examples/component_registration_example.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""
+Example of using the SpikeZoo component registration system.
+"""
+
+import sys
+import os
+import torch
+
+# Add the spikezoo package to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from spikezoo.core import (
+    ComponentRegistry,
+    ComponentInfo,
+    ComponentType,
+    register_component,
+    unregister_component,
+    get_component_info,
+    list_components,
+    list_components_by_type,
+    create_component,
+    create_component_with_config,
+    get_component_registry,
+    discover_components_from_directory,
+    check_component_dependencies
+)
+
+
+class SimplePreprocessor:
+    """Simple preprocessor for demonstration."""
+    
+    def __init__(self, normalize=True):
+        """Initialize preprocessor."""
+        self.normalize = normalize
+    
+    def preprocess(self, data):
+        """Preprocess data."""
+        if self.normalize:
+            data = (data - data.mean()) / (data.std() + 1e-8)
+        return data
+
+
+class SimplePostprocessor:
+    """Simple postprocessor for demonstration."""
+    
+    def __init__(self, clip_values=True):
+        """Initialize postprocessor."""
+        self.clip_values = clip_values
+    
+    def postprocess(self, data):
+        """Postprocess data."""
+        if self.clip_values:
+            data = torch.clamp(data, 0, 1)
+        return data
+
+
+class SimpleMetric:
+    """Simple metric for demonstration."""
+    
+    def __init__(self, reduction='mean'):
+        """Initialize metric."""
+        self.reduction = reduction
+    
+    def compute(self, pred, target):
+        """Compute metric."""
+        if self.reduction == 'mean':
+            return torch.mean((pred - target) ** 2).item()
+        else:
+            return torch.sum((pred - target) ** 2).item()
+
+
+class SimpleLoss:
+    """Simple loss for demonstration."""
+    
+    def __init__(self, reduction='mean'):
+        """Initialize loss."""
+        self.reduction = reduction
+    
+    def compute(self, pred, target):
+        """Compute loss."""
+        if self.reduction == 'mean':
+            return torch.mean((pred - target) ** 2)
+        else:
+            return torch.sum((pred - target) ** 2)
+
+
+def create_simple_preprocessor(config=None):
+    """Factory function for simple preprocessor."""
+    if config is None:
+        return SimplePreprocessor()
+    else:
+        return SimplePreprocessor(normalize=config.get('normalize', True))
+
+
+def create_simple_postprocessor(config=None):
+    """Factory function for simple postprocessor."""
+    if config is None:
+        return SimplePostprocessor()
+    else:
+        return SimplePostprocessor(clip_values=config.get('clip_values', True))
+
+
+def create_simple_metric(config=None):
+    """Factory function for simple metric."""
+    if config is None:
+        return SimpleMetric()
+    else:
+        return SimpleMetric(reduction=config.get('reduction', 'mean'))
+
+
+def create_simple_loss(config=None):
+    """Factory function for simple loss."""
+    if config is None:
+        return SimpleLoss()
+    else:
+        return SimpleLoss(reduction=config.get('reduction', 'mean'))
+
+
+def example_basic_registration():
+    """Example of basic component registration."""
+    print("=== Basic Component Registration Example ===\n")
+    
+    # Create registry
+    registry = ComponentRegistry()
+    
+    # Register preprocessor component
+    registry.register_component(
+        name="simple_preprocessor",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=SimplePreprocessor,
+        factory_function=create_simple_preprocessor,
+        version="1.0.0",
+        description="Simple data preprocessor",
+        author="Example Author",
+        category="preprocessing",
+        tags=["normalization", "simple"]
+    )
+    
+    print("1. Registered preprocessor component:")
+    component_info = registry.get_component_info("simple_preprocessor")
+    if component_info:
+        print(f"   Name: {component_info.name}")
+        print(f"   Type: {component_info.component_type.value}")
+        print(f"   Version: {component_info.version}")
+        print(f"   Description: {component_info.description}")
+        print(f"   Category: {component_info.category}")
+        print(f"   Tags: {component_info.tags}")
+    print()
+    
+    # Register postprocessor component
+    registry.register_component(
+        name="simple_postprocessor",
+        component_type=ComponentType.POSTPROCESSOR,
+        component_class=SimplePostprocessor,
+        factory_function=create_simple_postprocessor,
+        version="1.0.0",
+        description="Simple data postprocessor",
+        author="Example Author",
+        category="postprocessing",
+        tags=["clipping", "simple"]
+    )
+    
+    print("2. Registered postprocessor component:")
+    component_info = registry.get_component_info("simple_postprocessor")
+    if component_info:
+        print(f"   Name: {component_info.name}")
+        print(f"   Type: {component_info.component_type.value}")
+        print(f"   Description: {component_info.description}")
+        print(f"   Has factory function: {component_info.factory_function is not None}")
+    print()
+
+
+def example_component_creation():
+    """Example of component creation."""
+    print("=== Component Creation Example ===\n")
+    
+    # Create registry and register components
+    registry = ComponentRegistry()
+    registry.register_component(
+        name="simple_preprocessor",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=SimplePreprocessor,
+        factory_function=create_simple_preprocessor
+    )
+    
+    registry.register_component(
+        name="simple_postprocessor",
+        component_type=ComponentType.POSTPROCESSOR,
+        component_class=SimplePostprocessor,
+        factory_function=create_simple_postprocessor
+    )
+    
+    registry.register_component(
+        name="simple_metric",
+        component_type=ComponentType.METRIC,
+        component_class=SimpleMetric,
+        factory_function=create_simple_metric
+    )
+    
+    # Create component instances
+    print("1. Creating components:")
+    
+    # Create preprocessor with class
+    try:
+        preprocessor = registry.create_component("simple_preprocessor", normalize=False)
+        print(f"   Created simple_preprocessor: {type(preprocessor).__name__}")
+        print(f"   Normalize: {preprocessor.normalize}")
+    except Exception as e:
+        print(f"   Error creating simple_preprocessor: {e}")
+    
+    # Create postprocessor with factory function
+    try:
+        postprocessor = registry.create_component("simple_postprocessor")
+        print(f"   Created simple_postprocessor: {type(postprocessor).__name__}")
+        print(f"   Clip values: {postprocessor.clip_values}")
+    except Exception as e:
+        print(f"   Error creating simple_postprocessor: {e}")
+    
+    # Create metric with config
+    try:
+        config = {'reduction': 'sum'}
+        metric = registry.create_component_with_config("simple_metric", config)
+        print(f"   Created metric with config: {type(metric).__name__}")
+        print(f"   Reduction: {metric.reduction}")
+        
+        # Test metric computation
+        pred = torch.randn(10, 5)
+        target = torch.randn(10, 5)
+        result = metric.compute(pred, target)
+        print(f"   Computed metric result: {result:.6f}")
+    except Exception as e:
+        print(f"   Error creating metric with config: {e}")
+    
+    print()
+
+
+def example_global_registry():
+    """Example of using global registry."""
+    print("=== Global Registry Example ===\n")
+    
+    # Register components with global registry
+    register_component(
+        name="global_preprocessor",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=SimplePreprocessor,
+        factory_function=create_simple_preprocessor,
+        version="1.0.0",
+        description="Preprocessor registered globally",
+        author="Global Author",
+        category="preprocessing",
+        tags=["global", "simple"]
+    )
+    
+    print("1. Registered component with global registry:")
+    component_names = list_components()
+    print(f"   Registered components: {component_names}")
+    
+    component_info = get_component_info("global_preprocessor")
+    if component_info:
+        print(f"   Component info: {component_info.name} - {component_info.description}")
+    
+    # Create component using global registry
+    try:
+        preprocessor = create_component("global_preprocessor", normalize=True)
+        print(f"2. Created component using global registry: {type(preprocessor).__name__}")
+        print(f"   Normalize: {preprocessor.normalize}")
+    except Exception as e:
+        print(f"2. Error creating component: {e}")
+    
+    # Create component with config using global registry
+    try:
+        config = {'clip_values': False}
+        register_component(
+            name="global_postprocessor",
+            component_type=ComponentType.POSTPROCESSOR,
+            component_class=SimplePostprocessor,
+            factory_function=create_simple_postprocessor
+        )
+        
+        postprocessor = create_component_with_config("global_postprocessor", config)
+        print(f"3. Created component with config using global registry: {type(postprocessor).__name__}")
+        print(f"   Clip values: {postprocessor.clip_values}")
+    except Exception as e:
+        print(f"3. Error creating component with config: {e}")
+    
+    print()
+
+
+def example_component_listing():
+    """Example of listing components."""
+    print("=== Component Listing Example ===\n")
+    
+    # Create registry and register various components
+    registry = ComponentRegistry()
+    
+    # Register components of different types
+    registry.register_component(
+        name="data_normalizer",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=SimplePreprocessor,
+        category="preprocessing",
+        tags=["normalization", "data"]
+    )
+    
+    registry.register_component(
+        name="result_formatter",
+        component_type=ComponentType.POSTPROCESSOR,
+        component_class=SimplePostprocessor,
+        category="postprocessing",
+        tags=["formatting", "output"]
+    )
+    
+    registry.register_component(
+        name="accuracy_calculator",
+        component_type=ComponentType.METRIC,
+        component_class=SimpleMetric,
+        category="evaluation",
+        tags=["accuracy", "classification"]
+    )
+    
+    registry.register_component(
+        name="mse_loss",
+        component_type=ComponentType.LOSS,
+        component_class=SimpleLoss,
+        category="training",
+        tags=["mse", "regression"]
+    )
+    
+    print("1. All registered components:")
+    all_components = registry.list_components()
+    for component_name in all_components:
+        info = registry.get_component_info(component_name)
+        print(f"   - {component_name} ({info.component_type.value})")
+    print()
+    
+    print("2. Components by type:")
+    component_types = registry.get_component_types()
+    for comp_type in component_types:
+        components = registry.list_components_by_type(comp_type)
+        print(f"   {comp_type.value}: {components}")
+    print()
+    
+    print("3. Components by category:")
+    categories = registry.get_component_categories()
+    for category in categories:
+        components = registry.list_components_by_category(category)
+        print(f"   {category}: {components}")
+    print()
+    
+    print("4. Components by tag:")
+    tags = registry.get_component_tags()
+    for tag in tags:
+        components = registry.list_components_by_tag(tag)
+        print(f"   {tag}: {components}")
+    print()
+
+
+def example_component_usage():
+    """Example of using components in a pipeline."""
+    print("=== Component Usage Example ===\n")
+    
+    # Register and create components
+    registry = ComponentRegistry()
+    registry.register_component(
+        name="pipeline_preprocessor",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=SimplePreprocessor,
+        factory_function=create_simple_preprocessor
+    )
+    
+    registry.register_component(
+        name="pipeline_postprocessor",
+        component_type=ComponentType.POSTPROCESSOR,
+        component_class=SimplePostprocessor,
+        factory_function=create_simple_postprocessor
+    )
+    
+    registry.register_component(
+        name="pipeline_metric",
+        component_type=ComponentType.METRIC,
+        component_class=SimpleMetric,
+        factory_function=create_simple_metric
+    )
+    
+    try:
+        # Create components
+        preprocessor = registry.create_component("pipeline_preprocessor", normalize=True)
+        postprocessor = registry.create_component("pipeline_postprocessor", clip_values=True)
+        metric = registry.create_component("pipeline_metric", reduction='mean')
+        
+        print("1. Created pipeline components:")
+        print(f"   Preprocessor: {type(preprocessor).__name__}")
+        print(f"   Postprocessor: {type(postprocessor).__name__}")
+        print(f"   Metric: {type(metric).__name__}")
+        
+        # Simulate pipeline usage
+        print("\n2. Simulating pipeline usage:")
+        
+        # Raw data
+        raw_data = torch.randn(100, 10) * 10 + 5  # Large values
+        print(f"   Raw data range: [{raw_data.min():.2f}, {raw_data.max():.2f}]")
+        
+        # Preprocess
+        processed_data = preprocessor.preprocess(raw_data)
+        print(f"   Processed data range: [{processed_data.min():.2f}, {processed_data.max():.2f}]")
+        
+        # Simulate model output (add some noise)
+        model_output = processed_data + torch.randn_like(processed_data) * 0.1
+        
+        # Postprocess
+        final_output = postprocessor.postprocess(model_output)
+        print(f"   Final output range: [{final_output.min():.2f}, {final_output.max():.2f}]")
+        
+        # Evaluate
+        target = processed_data  # Ideal target
+        metric_result = metric.compute(final_output, target)
+        print(f"   Metric result: {metric_result:.6f}")
+        
+    except Exception as e:
+        print(f"   Error using components: {e}")
+    
+    print()
+
+
+def example_component_dependencies():
+    """Example of component dependencies."""
+    print("=== Component Dependencies Example ===\n")
+    
+    registry = ComponentRegistry()
+    
+    # Register a component with dependencies
+    registry.register_component(
+        name="dependent_component",
+        component_type=ComponentType.CUSTOM,
+        description="Component with dependencies",
+        dependencies=["base_component", "helper_component"]
+    )
+    
+    print("1. Registered component with dependencies:")
+    component_info = registry.get_component_info("dependent_component")
+    if component_info:
+        print(f"   Name: {component_info.name}")
+        print(f"   Dependencies: {component_info.dependencies}")
+    
+    # Check dependencies (should fail since dependencies are not registered)
+    deps_satisfied = registry.check_dependencies("dependent_component")
+    print(f"2. Dependencies satisfied: {deps_satisfied}")
+    
+    # Register dependencies
+    registry.register_component(
+        name="base_component",
+        component_type=ComponentType.CUSTOM,
+        description="Base component"
+    )
+    
+    registry.register_component(
+        name="helper_component",
+        component_type=ComponentType.CUSTOM,
+        description="Helper component"
+    )
+    
+    print("3. Registered dependencies:")
+    print("   - base_component")
+    print("   - helper_component")
+    
+    # Check dependencies again (should pass now)
+    deps_satisfied = registry.check_dependencies("dependent_component")
+    print(f"4. Dependencies satisfied: {deps_satisfied}")
+    
+    print()
+
+
+def example_error_handling():
+    """Example of error handling."""
+    print("=== Error Handling Example ===\n")
+    
+    registry = ComponentRegistry()
+    
+    print("1. Trying to create unregistered component:")
+    try:
+        component = registry.create_component("nonexistent_component")
+    except ValueError as e:
+        print(f"   Caught expected error: {e}")
+    
+    print("\n2. Registering component without class or factory:")
+    registry.register_component(
+        name="incomplete_component",
+        component_type=ComponentType.CUSTOM,
+        description="Component without creation method"
+    )
+    
+    print("   Trying to create incomplete component:")
+    try:
+        component = registry.create_component("incomplete_component")
+    except ValueError as e:
+        print(f"   Caught expected error: {e}")
+    
+    print()
+
+
+if __name__ == "__main__":
+    example_basic_registration()
+    example_component_creation()
+    example_global_registry()
+    example_component_listing()
+    example_component_usage()
+    example_component_dependencies()
+    example_error_handling()

--- a/spikezoo/core/__init__.py
+++ b/spikezoo/core/__init__.py
@@ -3,6 +3,7 @@ from .plugin_base import PluginBase
 from .task_runner import TaskRunner
 from .model_registry import ModelRegistry, ModelInfo
 from .dataset_registry import DatasetRegistry, DatasetInfo
+from .component_registry import ComponentRegistry, ComponentInfo, ComponentType
 
 __all__ = [
     "TaskManager",
@@ -12,5 +13,8 @@ __all__ = [
     "ModelRegistry",
     "ModelInfo",
     "DatasetRegistry",
-    "DatasetInfo"
+    "DatasetInfo",
+    "ComponentRegistry",
+    "ComponentInfo",
+    "ComponentType"
 ]

--- a/spikezoo/core/component_registry.py
+++ b/spikezoo/core/component_registry.py
@@ -1,0 +1,507 @@
+from typing import Dict, Type, Optional, Callable, Any, Union
+from dataclasses import dataclass, field
+import importlib
+import logging
+from pathlib import Path
+import os
+from enum import Enum
+
+
+class ComponentType(Enum):
+    """Component types."""
+    MODEL = "model"
+    DATASET = "dataset"
+    PIPELINE = "pipeline"
+    PREPROCESSOR = "preprocessor"
+    POSTPROCESSOR = "postprocessor"
+    METRIC = "metric"
+    LOSS = "loss"
+    OPTIMIZER = "optimizer"
+    SCHEDULER = "scheduler"
+    CUSTOM = "custom"
+
+
+@dataclass
+class ComponentInfo:
+    """Component information."""
+    name: str
+    component_type: ComponentType
+    version: str = "1.0.0"
+    description: str = ""
+    author: str = ""
+    category: str = "general"
+    tags: list = field(default_factory=list)
+    config_class: Optional[Type] = None
+    component_class: Optional[Type] = None
+    factory_function: Optional[Callable] = None
+    dependencies: list = field(default_factory=list)
+
+
+class ComponentRegistry:
+    """Registry for managing pipeline components and their plugins."""
+    
+    def __init__(self):
+        """Initialize component registry."""
+        self.components: Dict[str, ComponentInfo] = {}
+        self.factories: Dict[str, Callable] = {}
+        self.logger = logging.getLogger(__name__)
+        self._discovered_modules = set()
+    
+    def register_component(
+        self, 
+        name: str,
+        component_type: ComponentType,
+        component_class: Optional[Type] = None,
+        config_class: Optional[Type] = None,
+        factory_function: Optional[Callable] = None,
+        version: str = "1.0.0",
+        description: str = "",
+        author: str = "",
+        category: str = "general",
+        tags: Optional[list] = None,
+        dependencies: Optional[list] = None
+    ):
+        """
+        Register a component.
+        
+        Args:
+            name: Component name
+            component_type: Component type
+            component_class: Component class (optional)
+            config_class: Configuration class (optional)
+            factory_function: Factory function to create component instance (optional)
+            version: Component version
+            description: Component description
+            author: Component author
+            category: Component category
+            tags: Component tags
+            dependencies: Component dependencies
+        """
+        if name in self.components:
+            self.logger.warning(f"Component {name} already registered, overwriting")
+        
+        component_info = ComponentInfo(
+            name=name,
+            component_type=component_type,
+            version=version,
+            description=description,
+            author=author,
+            category=category,
+            tags=tags or [],
+            config_class=config_class,
+            component_class=component_class,
+            factory_function=factory_function,
+            dependencies=dependencies or []
+        )
+        
+        self.components[name] = component_info
+        
+        # Register factory function if provided
+        if factory_function:
+            self.factories[name] = factory_function
+        
+        self.logger.info(f"Registered component: {name} ({component_type.value})")
+    
+    def unregister_component(self, name: str):
+        """
+        Unregister a component.
+        
+        Args:
+            name: Component name
+        """
+        if name in self.components:
+            component_type = self.components[name].component_type.value
+            del self.components[name]
+            self.logger.info(f"Unregistered component: {name} ({component_type})")
+        
+        if name in self.factories:
+            del self.factories[name]
+    
+    def get_component_info(self, name: str) -> Optional[ComponentInfo]:
+        """
+        Get component information.
+        
+        Args:
+            name: Component name
+            
+        Returns:
+            ComponentInfo or None if not found
+        """
+        return self.components.get(name)
+    
+    def list_components(self) -> list:
+        """
+        List all registered components.
+        
+        Returns:
+            List of component names
+        """
+        return list(self.components.keys())
+    
+    def list_components_by_type(self, component_type: Union[ComponentType, str]) -> list:
+        """
+        List components by type.
+        
+        Args:
+            component_type: Component type
+            
+        Returns:
+            List of component names of the specified type
+        """
+        if isinstance(component_type, str):
+            component_type = ComponentType(component_type)
+        
+        return [name for name, info in self.components.items() if info.component_type == component_type]
+    
+    def list_components_by_category(self, category: str) -> list:
+        """
+        List components by category.
+        
+        Args:
+            category: Component category
+            
+        Returns:
+            List of component names in the category
+        """
+        return [name for name, info in self.components.items() if info.category == category]
+    
+    def list_components_by_tag(self, tag: str) -> list:
+        """
+        List components by tag.
+        
+        Args:
+            tag: Component tag
+            
+        Returns:
+            List of component names with the tag
+        """
+        return [name for name, info in self.components.items() if tag in info.tags]
+    
+    def create_component(self, name: str, *args, **kwargs) -> Any:
+        """
+        Create component instance.
+        
+        Args:
+            name: Component name
+            *args: Positional arguments for component constructor
+            **kwargs: Keyword arguments for component constructor
+            
+        Returns:
+            Component instance
+            
+        Raises:
+            ValueError: If component not found or cannot be created
+        """
+        if name not in self.components:
+            raise ValueError(f"Component {name} not found in registry")
+        
+        component_info = self.components[name]
+        
+        # Try factory function first
+        if name in self.factories:
+            try:
+                return self.factories[name](*args, **kwargs)
+            except Exception as e:
+                self.logger.error(f"Failed to create component {name} using factory: {e}")
+                raise
+        
+        # Try component class
+        if component_info.component_class:
+            try:
+                return component_info.component_class(*args, **kwargs)
+            except Exception as e:
+                self.logger.error(f"Failed to create component {name} using class: {e}")
+                raise
+        
+        raise ValueError(f"Cannot create component {name}: no factory function or component class available")
+    
+    def create_component_with_config(self, name: str, config: Any) -> Any:
+        """
+        Create component instance with configuration.
+        
+        Args:
+            name: Component name
+            config: Component configuration
+            
+        Returns:
+            Component instance
+            
+        Raises:
+            ValueError: If component not found or cannot be created
+        """
+        if name not in self.components:
+            raise ValueError(f"Component {name} not found in registry")
+        
+        component_info = self.components[name]
+        
+        # Try factory function with config
+        if name in self.factories:
+            try:
+                return self.factories[name](config)
+            except Exception as e:
+                self.logger.error(f"Failed to create component {name} using factory with config: {e}")
+                raise
+        
+        # Try component class with config
+        if component_info.component_class:
+            try:
+                return component_info.component_class(config)
+            except Exception as e:
+                self.logger.error(f"Failed to create component {name} using class with config: {e}")
+                raise
+        
+        raise ValueError(f"Cannot create component {name}: no factory function or component class available")
+    
+    def discover_components_from_directory(self, directory: str, package_prefix: str = ""):
+        """
+        Discover and register components from a directory.
+        
+        Args:
+            directory: Directory to search for components
+            package_prefix: Package prefix for import
+        """
+        directory = Path(directory)
+        if not directory.exists():
+            self.logger.warning(f"Directory {directory} does not exist")
+            return
+        
+        # Walk through directory
+        for root, dirs, files in os.walk(directory):
+            for file in files:
+                if file.endswith("_component.py") or file.endswith("_plugin.py"):
+                    module_name = file[:-3]  # Remove .py extension
+                    full_module_name = f"{package_prefix}.{module_name}" if package_prefix else module_name
+                    
+                    # Skip if already discovered
+                    if full_module_name in self._discovered_modules:
+                        continue
+                    
+                    try:
+                        # Import module
+                        module = importlib.import_module(full_module_name)
+                        self._discovered_modules.add(full_module_name)
+                        
+                        # Look for component registration function
+                        if hasattr(module, "register_components"):
+                            module.register_components(self)
+                            self.logger.info(f"Discovered components from {full_module_name}")
+                    except Exception as e:
+                        self.logger.warning(f"Failed to import module {full_module_name}: {e}")
+    
+    def get_component_types(self) -> list:
+        """
+        Get all component types.
+        
+        Returns:
+            List of unique component types
+        """
+        types = set()
+        for info in self.components.values():
+            types.add(info.component_type)
+        return list(types)
+    
+    def get_component_categories(self) -> list:
+        """
+        Get all component categories.
+        
+        Returns:
+            List of unique categories
+        """
+        categories = set()
+        for info in self.components.values():
+            categories.add(info.category)
+        return list(categories)
+    
+    def get_component_tags(self) -> list:
+        """
+        Get all component tags.
+        
+        Returns:
+            List of unique tags
+        """
+        tags = set()
+        for info in self.components.values():
+            tags.update(info.tags)
+        return list(tags)
+    
+    def get_component_dependencies(self, name: str) -> list:
+        """
+        Get component dependencies.
+        
+        Args:
+            name: Component name
+            
+        Returns:
+            List of component dependencies
+        """
+        if name not in self.components:
+            return []
+        
+        return self.components[name].dependencies
+    
+    def check_dependencies(self, name: str) -> bool:
+        """
+        Check if all component dependencies are satisfied.
+        
+        Args:
+            name: Component name
+            
+        Returns:
+            True if all dependencies are satisfied, False otherwise
+        """
+        if name not in self.components:
+            return False
+        
+        dependencies = self.components[name].dependencies
+        for dep in dependencies:
+            if dep not in self.components:
+                return False
+        return True
+
+
+# Global component registry instance
+_component_registry = ComponentRegistry()
+
+
+def register_component(
+    name: str,
+    component_type: ComponentType,
+    component_class: Optional[Type] = None,
+    config_class: Optional[Type] = None,
+    factory_function: Optional[Callable] = None,
+    version: str = "1.0.0",
+    description: str = "",
+    author: str = "",
+    category: str = "general",
+    tags: Optional[list] = None,
+    dependencies: Optional[list] = None
+):
+    """
+    Register a component in the global registry.
+    
+    Args:
+        name: Component name
+        component_type: Component type
+        component_class: Component class (optional)
+        config_class: Configuration class (optional)
+        factory_function: Factory function to create component instance (optional)
+        version: Component version
+        description: Component description
+        author: Component author
+        category: Component category
+        tags: Component tags
+        dependencies: Component dependencies
+    """
+    _component_registry.register_component(
+        name, component_type, component_class, config_class, factory_function,
+        version, description, author, category, tags, dependencies
+    )
+
+
+def unregister_component(name: str):
+    """
+    Unregister a component from the global registry.
+    
+    Args:
+        name: Component name
+    """
+    _component_registry.unregister_component(name)
+
+
+def get_component_info(name: str) -> Optional[ComponentInfo]:
+    """
+    Get component information from the global registry.
+    
+    Args:
+        name: Component name
+        
+    Returns:
+        ComponentInfo or None if not found
+    """
+    return _component_registry.get_component_info(name)
+
+
+def list_components() -> list:
+    """
+    List all registered components from the global registry.
+    
+    Returns:
+        List of component names
+    """
+    return _component_registry.list_components()
+
+
+def list_components_by_type(component_type: Union[ComponentType, str]) -> list:
+    """
+    List components by type from the global registry.
+    
+    Args:
+        component_type: Component type
+        
+    Returns:
+        List of component names of the specified type
+    """
+    return _component_registry.list_components_by_type(component_type)
+
+
+def create_component(name: str, *args, **kwargs) -> Any:
+    """
+    Create component instance from the global registry.
+    
+    Args:
+        name: Component name
+        *args: Positional arguments for component constructor
+        **kwargs: Keyword arguments for component constructor
+        
+    Returns:
+        Component instance
+    """
+    return _component_registry.create_component(name, *args, **kwargs)
+
+
+def create_component_with_config(name: str, config: Any) -> Any:
+    """
+    Create component instance with configuration from the global registry.
+    
+    Args:
+        name: Component name
+        config: Component configuration
+        
+    Returns:
+        Component instance
+    """
+    return _component_registry.create_component_with_config(name, config)
+
+
+def get_component_registry() -> ComponentRegistry:
+    """
+    Get the global component registry instance.
+    
+    Returns:
+        ComponentRegistry instance
+    """
+    return _component_registry
+
+
+def discover_components_from_directory(directory: str, package_prefix: str = ""):
+    """
+    Discover and register components from a directory in the global registry.
+    
+    Args:
+        directory: Directory to search for components
+        package_prefix: Package prefix for import
+    """
+    _component_registry.discover_components_from_directory(directory, package_prefix)
+
+
+def check_component_dependencies(name: str) -> bool:
+    """
+    Check if all component dependencies are satisfied in the global registry.
+    
+    Args:
+        name: Component name
+        
+    Returns:
+        True if all dependencies are satisfied, False otherwise
+    """
+    return _component_registry.check_dependencies(name)

--- a/spikezoo/plugins/component_plugin_example.py
+++ b/spikezoo/plugins/component_plugin_example.py
@@ -1,0 +1,148 @@
+from spikezoo.core import register_component, ComponentType
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset
+
+
+class ExamplePreprocessor:
+    """Example preprocessor component."""
+    
+    def __init__(self, config=None):
+        """Initialize preprocessor."""
+        self.config = config or {}
+        self.normalize = self.config.get('normalize', True)
+    
+    def preprocess(self, data):
+        """Preprocess data."""
+        if self.normalize:
+            data = (data - data.mean()) / (data.std() + 1e-8)
+        return data
+
+
+class ExamplePostprocessor:
+    """Example postprocessor component."""
+    
+    def __init__(self, config=None):
+        """Initialize postprocessor."""
+        self.config = config or {}
+        self.clip_values = self.config.get('clip_values', True)
+    
+    def postprocess(self, data):
+        """Postprocess data."""
+        if self.clip_values:
+            data = torch.clamp(data, 0, 1)
+        return data
+
+
+class ExampleMetric:
+    """Example metric component."""
+    
+    def __init__(self, config=None):
+        """Initialize metric."""
+        self.config = config or {}
+        self.reduction = self.config.get('reduction', 'mean')
+    
+    def compute(self, pred, target):
+        """Compute metric."""
+        mse = torch.mean((pred - target) ** 2)
+        return mse.item()
+
+
+class ExampleLoss:
+    """Example loss component."""
+    
+    def __init__(self, config=None):
+        """Initialize loss."""
+        self.config = config or {}
+        self.reduction = self.config.get('reduction', 'mean')
+    
+    def compute(self, pred, target):
+        """Compute loss."""
+        loss = torch.mean((pred - target) ** 2)
+        return loss
+
+
+def create_example_preprocessor(config=None):
+    """Factory function for example preprocessor."""
+    return ExamplePreprocessor(config)
+
+
+def create_example_postprocessor(config=None):
+    """Factory function for example postprocessor."""
+    return ExamplePostprocessor(config)
+
+
+def create_example_metric(config=None):
+    """Factory function for example metric."""
+    return ExampleMetric(config)
+
+
+def create_example_loss(config=None):
+    """Factory function for example loss."""
+    return ExampleLoss(config)
+
+
+def register_components(registry):
+    """
+    Register components with the registry.
+    
+    Args:
+        registry: ComponentRegistry instance
+    """
+    # Register preprocessor
+    registry.register_component(
+        name="example_preprocessor",
+        component_type=ComponentType.PREPROCESSOR,
+        component_class=ExamplePreprocessor,
+        factory_function=create_example_preprocessor,
+        version="1.0.0",
+        description="Example preprocessor component",
+        author="SpikeZoo Team",
+        category="preprocessing",
+        tags=["example", "normalization"]
+    )
+    
+    # Register postprocessor
+    registry.register_component(
+        name="example_postprocessor",
+        component_type=ComponentType.POSTPROCESSOR,
+        component_class=ExamplePostprocessor,
+        factory_function=create_example_postprocessor,
+        version="1.0.0",
+        description="Example postprocessor component",
+        author="SpikeZoo Team",
+        category="postprocessing",
+        tags=["example", "clipping"]
+    )
+    
+    # Register metric
+    registry.register_component(
+        name="example_metric",
+        component_type=ComponentType.METRIC,
+        component_class=ExampleMetric,
+        factory_function=create_example_metric,
+        version="1.0.0",
+        description="Example metric component",
+        author="SpikeZoo Team",
+        category="evaluation",
+        tags=["example", "mse"]
+    )
+    
+    # Register loss
+    registry.register_component(
+        name="example_loss",
+        component_type=ComponentType.LOSS,
+        component_class=ExampleLoss,
+        factory_function=create_example_loss,
+        version="1.0.0",
+        description="Example loss component",
+        author="SpikeZoo Team",
+        category="training",
+        tags=["example", "mse"],
+        dependencies=[]
+    )
+
+
+# Register with global registry when module is imported
+register_components(register_component.__globals__['registry'] if 'registry' in register_component.__globals__ else 
+                   __import__('spikezoo.core.component_registry').core.component_registry._component_registry)

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,553 @@
+import unittest
+import sys
+import os
+import torch
+
+# Add the spikezoo package to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from spikezoo.core.component_registry import (
+    ComponentRegistry,
+    ComponentInfo,
+    ComponentType,
+    register_component,
+    unregister_component,
+    get_component_info,
+    list_components,
+    list_components_by_type,
+    create_component,
+    create_component_with_config,
+    get_component_registry,
+    discover_components_from_directory,
+    check_component_dependencies
+)
+
+
+class TestComponentInfo(unittest.TestCase):
+    """ComponentInfo unit tests."""
+    
+    def test_component_info_creation(self):
+        """Test ComponentInfo creation."""
+        component_info = ComponentInfo(
+            name="test_component",
+            component_type=ComponentType.MODEL,
+            version="1.0.0",
+            description="Test component",
+            author="Test Author",
+            category="test",
+            tags=["tag1", "tag2"],
+            dependencies=["dep1", "dep2"]
+        )
+        
+        self.assertEqual(component_info.name, "test_component")
+        self.assertEqual(component_info.component_type, ComponentType.MODEL)
+        self.assertEqual(component_info.version, "1.0.0")
+        self.assertEqual(component_info.description, "Test component")
+        self.assertEqual(component_info.author, "Test Author")
+        self.assertEqual(component_info.category, "test")
+        self.assertEqual(component_info.tags, ["tag1", "tag2"])
+        self.assertEqual(component_info.dependencies, ["dep1", "dep2"])
+        self.assertIsNone(component_info.config_class)
+        self.assertIsNone(component_info.component_class)
+        self.assertIsNone(component_info.factory_function)
+
+
+class TestComponentRegistry(unittest.TestCase):
+    """ComponentRegistry unit tests."""
+    
+    def setUp(self):
+        """Test setup."""
+        self.registry = ComponentRegistry()
+    
+    def test_register_component_with_class(self):
+        """Test registering component with class."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+            
+            def process(self):
+                return "processed"
+        
+        self.registry.register_component(
+            name="test_component",
+            component_type=ComponentType.PREPROCESSOR,
+            component_class=TestComponent,
+            version="1.0.0",
+            description="Test component with class"
+        )
+        
+        # Check registration
+        self.assertIn("test_component", self.registry.components)
+        component_info = self.registry.get_component_info("test_component")
+        self.assertIsNotNone(component_info)
+        self.assertEqual(component_info.name, "test_component")
+        self.assertEqual(component_info.component_type, ComponentType.PREPROCESSOR)
+        self.assertEqual(component_info.component_class, TestComponent)
+    
+    def test_register_component_with_factory(self):
+        """Test registering component with factory function."""
+        def create_component():
+            class SimpleComponent:
+                def __init__(self):
+                    self.name = "simple"
+                
+                def process(self):
+                    return "simple_processed"
+            return SimpleComponent()
+        
+        self.registry.register_component(
+            name="factory_component",
+            component_type=ComponentType.POSTPROCESSOR,
+            factory_function=create_component,
+            version="1.0.0",
+            description="Test component with factory"
+        )
+        
+        # Check registration
+        self.assertIn("factory_component", self.registry.components)
+        self.assertIn("factory_component", self.registry.factories)
+        component_info = self.registry.get_component_info("factory_component")
+        self.assertIsNotNone(component_info)
+        self.assertEqual(component_info.name, "factory_component")
+        self.assertEqual(component_info.component_type, ComponentType.POSTPROCESSOR)
+        self.assertEqual(component_info.factory_function, create_component)
+    
+    def test_unregister_component(self):
+        """Test unregistering component."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+            
+            def process(self):
+                return "processed"
+        
+        self.registry.register_component(name="test_component", component_type=ComponentType.MODEL, component_class=TestComponent)
+        self.assertIn("test_component", self.registry.components)
+        
+        self.registry.unregister_component("test_component")
+        self.assertNotIn("test_component", self.registry.components)
+        self.assertNotIn("test_component", self.registry.factories)
+    
+    def test_get_component_info(self):
+        """Test getting component info."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+            
+            def process(self):
+                return "processed"
+        
+        self.registry.register_component(
+            name="test_component",
+            component_type=ComponentType.MODEL,
+            component_class=TestComponent,
+            description="Test component"
+        )
+        
+        # Get existing component info
+        component_info = self.registry.get_component_info("test_component")
+        self.assertIsNotNone(component_info)
+        self.assertEqual(component_info.name, "test_component")
+        self.assertEqual(component_info.description, "Test component")
+        
+        # Get non-existent component info
+        component_info = self.registry.get_component_info("non_existent")
+        self.assertIsNone(component_info)
+    
+    def test_list_components(self):
+        """Test listing components."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1)
+        self.registry.register_component(name="component2", component_type=ComponentType.DATASET, component_class=TestComponent2)
+        
+        components = self.registry.list_components()
+        self.assertIn("component1", components)
+        self.assertIn("component2", components)
+        self.assertEqual(len(components), 2)
+    
+    def test_list_components_by_type(self):
+        """Test listing components by type."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1)
+        self.registry.register_component(name="component2", component_type=ComponentType.DATASET, component_class=TestComponent2)
+        
+        model_components = self.registry.list_components_by_type(ComponentType.MODEL)
+        dataset_components = self.registry.list_components_by_type(ComponentType.DATASET)
+        
+        self.assertIn("component1", model_components)
+        self.assertNotIn("component2", model_components)
+        self.assertIn("component2", dataset_components)
+        self.assertNotIn("component1", dataset_components)
+    
+    def test_list_components_by_category(self):
+        """Test listing components by category."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1, category="vision")
+        self.registry.register_component(name="component2", component_type=ComponentType.MODEL, component_class=TestComponent2, category="nlp")
+        
+        vision_components = self.registry.list_components_by_category("vision")
+        nlp_components = self.registry.list_components_by_category("nlp")
+        
+        self.assertIn("component1", vision_components)
+        self.assertNotIn("component2", vision_components)
+        self.assertIn("component2", nlp_components)
+        self.assertNotIn("component1", nlp_components)
+    
+    def test_list_components_by_tag(self):
+        """Test listing components by tag."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1, tags=["cnn", "image"])
+        self.registry.register_component(name="component2", component_type=ComponentType.MODEL, component_class=TestComponent2, tags=["rnn", "text"])
+        self.registry.register_component(name="component3", component_type=ComponentType.MODEL, component_class=TestComponent1, tags=["cnn", "audio"])
+        
+        cnn_components = self.registry.list_components_by_tag("cnn")
+        rnn_components = self.registry.list_components_by_tag("rnn")
+        
+        self.assertIn("component1", cnn_components)
+        self.assertIn("component3", cnn_components)
+        self.assertNotIn("component2", cnn_components)
+        self.assertIn("component2", rnn_components)
+        self.assertNotIn("component1", rnn_components)
+        self.assertNotIn("component3", rnn_components)
+    
+    def test_create_component_with_class(self):
+        """Test creating component with class."""
+        class TestComponent:
+            def __init__(self, name="default"):
+                self.name = name
+            
+            def process(self):
+                return f"processed_{self.name}"
+        
+        self.registry.register_component(name="test_component", component_type=ComponentType.PREPROCESSOR, component_class=TestComponent)
+        
+        # Create component
+        component = self.registry.create_component("test_component", name="custom")
+        self.assertIsInstance(component, TestComponent)
+        self.assertEqual(component.name, "custom")
+        self.assertEqual(component.process(), "processed_custom")
+    
+    def test_create_component_with_factory(self):
+        """Test creating component with factory function."""
+        def create_component(name="default"):
+            class SimpleComponent:
+                def __init__(self, name):
+                    self.name = name
+                
+                def process(self):
+                    return f"simple_{self.name}"
+            return SimpleComponent(name)
+        
+        self.registry.register_component(name="factory_component", component_type=ComponentType.POSTPROCESSOR, factory_function=create_component)
+        
+        # Create component
+        component = self.registry.create_component("factory_component", "custom")
+        self.assertEqual(component.process(), "simple_custom")
+    
+    def test_create_component_with_config(self):
+        """Test creating component with config."""
+        class TestComponent:
+            def __init__(self, config=None):
+                if config:
+                    self.name = config.get('name', 'default')
+                    self.value = config.get('value', 0)
+                else:
+                    self.name = 'default'
+                    self.value = 0
+            
+            def process(self):
+                return f"{self.name}_{self.value}"
+        
+        class TestConfig:
+            def __init__(self, name="default", value=0):
+                self.name = name
+                self.value = value
+        
+        self.registry.register_component(name="config_component", component_type=ComponentType.METRIC, component_class=TestComponent)
+        
+        # Create component with config
+        config = {'name': 'custom', 'value': 42}
+        component = self.registry.create_component_with_config("config_component", config)
+        self.assertIsInstance(component, TestComponent)
+        self.assertEqual(component.name, "custom")
+        self.assertEqual(component.value, 42)
+        self.assertEqual(component.process(), "custom_42")
+    
+    def test_create_component_not_found(self):
+        """Test creating non-existent component."""
+        with self.assertRaises(ValueError):
+            self.registry.create_component("non_existent_component")
+    
+    def test_create_component_no_creation_method(self):
+        """Test creating component without creation method."""
+        self.registry.register_component(name="incomplete_component", component_type=ComponentType.CUSTOM, description="No class or factory")
+        
+        with self.assertRaises(ValueError):
+            self.registry.create_component("incomplete_component")
+    
+    def test_get_component_types(self):
+        """Test getting component types."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1)
+        self.registry.register_component(name="component2", component_type=ComponentType.DATASET, component_class=TestComponent2)
+        self.registry.register_component(name="component3", component_type=ComponentType.MODEL, component_class=TestComponent1)
+        
+        types = self.registry.get_component_types()
+        self.assertIn(ComponentType.MODEL, types)
+        self.assertIn(ComponentType.DATASET, types)
+        self.assertEqual(len(types), 2)
+    
+    def test_get_component_categories(self):
+        """Test getting component categories."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1, category="vision")
+        self.registry.register_component(name="component2", component_type=ComponentType.MODEL, component_class=TestComponent2, category="nlp")
+        self.registry.register_component(name="component3", component_type=ComponentType.MODEL, component_class=TestComponent1, category="vision")
+        
+        categories = self.registry.get_component_categories()
+        self.assertIn("vision", categories)
+        self.assertIn("nlp", categories)
+        self.assertEqual(len(categories), 2)
+    
+    def test_get_component_tags(self):
+        """Test getting component tags."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        self.registry.register_component(name="component1", component_type=ComponentType.MODEL, component_class=TestComponent1, tags=["cnn", "image"])
+        self.registry.register_component(name="component2", component_type=ComponentType.MODEL, component_class=TestComponent2, tags=["rnn", "text"])
+        self.registry.register_component(name="component3", component_type=ComponentType.MODEL, component_class=TestComponent1, tags=["cnn", "audio"])
+        
+        tags = self.registry.get_component_tags()
+        self.assertIn("cnn", tags)
+        self.assertIn("image", tags)
+        self.assertIn("rnn", tags)
+        self.assertIn("text", tags)
+        self.assertIn("audio", tags)
+        self.assertEqual(len(tags), 5)
+    
+    def test_get_component_dependencies(self):
+        """Test getting component dependencies."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+        
+        self.registry.register_component(
+            name="dependent_component",
+            component_type=ComponentType.CUSTOM,
+            component_class=TestComponent,
+            dependencies=["base", "helper"]
+        )
+        
+        dependencies = self.registry.get_component_dependencies("dependent_component")
+        self.assertEqual(dependencies, ["base", "helper"])
+        
+        # Test non-existent component
+        dependencies = self.registry.get_component_dependencies("non_existent")
+        self.assertEqual(dependencies, [])
+    
+    def test_check_dependencies(self):
+        """Test checking component dependencies."""
+        # Register component with dependencies
+        self.registry.register_component(
+            name="dependent_component",
+            component_type=ComponentType.CUSTOM,
+            dependencies=["base_component", "helper_component"]
+        )
+        
+        # Check dependencies before registering dependencies (should fail)
+        satisfied = self.registry.check_dependencies("dependent_component")
+        self.assertFalse(satisfied)
+        
+        # Register dependencies
+        self.registry.register_component(name="base_component", component_type=ComponentType.CUSTOM)
+        self.registry.register_component(name="helper_component", component_type=ComponentType.CUSTOM)
+        
+        # Check dependencies after registering dependencies (should pass)
+        satisfied = self.registry.check_dependencies("dependent_component")
+        self.assertTrue(satisfied)
+        
+        # Test non-existent component
+        satisfied = self.registry.check_dependencies("non_existent")
+        self.assertFalse(satisfied)
+
+
+class TestGlobalFunctions(unittest.TestCase):
+    """Test global component registry functions."""
+    
+    def setUp(self):
+        """Test setup - clear global registry."""
+        # Clear global registry for testing
+        global_registry = get_component_registry()
+        global_registry.components.clear()
+        global_registry.factories.clear()
+    
+    def test_register_component_global(self):
+        """Test global register_component function."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+            
+            def process(self):
+                return "processed"
+        
+        register_component(name="global_test_component", component_type=ComponentType.MODEL, component_class=TestComponent)
+        
+        component_names = list_components()
+        self.assertIn("global_test_component", component_names)
+        
+        component_info = get_component_info("global_test_component")
+        self.assertIsNotNone(component_info)
+        self.assertEqual(component_info.name, "global_test_component")
+    
+    def test_unregister_component_global(self):
+        """Test global unregister_component function."""
+        class TestComponent:
+            def __init__(self):
+                self.name = "test"
+            
+            def process(self):
+                return "processed"
+        
+        register_component(name="global_test_component", component_type=ComponentType.MODEL, component_class=TestComponent)
+        self.assertIn("global_test_component", list_components())
+        
+        unregister_component("global_test_component")
+        self.assertNotIn("global_test_component", list_components())
+    
+    def test_list_components_by_type_global(self):
+        """Test global list_components_by_type function."""
+        class TestComponent1:
+            def __init__(self):
+                self.name = "test1"
+        
+        class TestComponent2:
+            def __init__(self):
+                self.name = "test2"
+        
+        register_component(name="global_component1", component_type=ComponentType.MODEL, component_class=TestComponent1)
+        register_component(name="global_component2", component_type=ComponentType.DATASET, component_class=TestComponent2)
+        
+        model_components = list_components_by_type(ComponentType.MODEL)
+        dataset_components = list_components_by_type(ComponentType.DATASET)
+        
+        self.assertIn("global_component1", model_components)
+        self.assertNotIn("global_component2", model_components)
+        self.assertIn("global_component2", dataset_components)
+        self.assertNotIn("global_component1", dataset_components)
+    
+    def test_create_component_global(self):
+        """Test global create_component function."""
+        class TestComponent:
+            def __init__(self, name="default"):
+                self.name = name
+            
+            def process(self):
+                return f"global_{self.name}"
+        
+        register_component(name="global_test_component", component_type=ComponentType.PREPROCESSOR, component_class=TestComponent)
+        
+        component = create_component("global_test_component", name="custom")
+        self.assertIsInstance(component, TestComponent)
+        self.assertEqual(component.name, "custom")
+        self.assertEqual(component.process(), "global_custom")
+    
+    def test_create_component_with_config_global(self):
+        """Test global create_component_with_config function."""
+        class TestComponent:
+            def __init__(self, config=None):
+                if config:
+                    self.name = config.get('name', 'default')
+                else:
+                    self.name = 'default'
+            
+            def process(self):
+                return f"global_{self.name}"
+        
+        register_component(name="global_config_component", component_type=ComponentType.POSTPROCESSOR, component_class=TestComponent)
+        
+        config = {'name': 'custom'}
+        component = create_component_with_config("global_config_component", config)
+        self.assertIsInstance(component, TestComponent)
+        self.assertEqual(component.name, "custom")
+        self.assertEqual(component.process(), "global_custom")
+    
+    def test_get_component_registry_global(self):
+        """Test global get_component_registry function."""
+        registry = get_component_registry()
+        self.assertIsInstance(registry, ComponentRegistry)
+        
+        # Test that it's the same instance
+        registry2 = get_component_registry()
+        self.assertIs(registry, registry2)
+    
+    def test_check_component_dependencies_global(self):
+        """Test global check_component_dependencies function."""
+        # Register component with dependencies
+        register_component(
+            name="global_dependent_component",
+            component_type=ComponentType.CUSTOM,
+            dependencies=["global_base_component"]
+        )
+        
+        # Check dependencies before registering dependencies (should fail)
+        satisfied = check_component_dependencies("global_dependent_component")
+        self.assertFalse(satisfied)
+        
+        # Register dependency
+        register_component(name="global_base_component", component_type=ComponentType.CUSTOM)
+        
+        # Check dependencies after registering dependencies (should pass)
+        satisfied = check_component_dependencies("global_dependent_component")
+        self.assertTrue(satisfied)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 🛠️ Dev Bot · TASK-TASK-023

### 📝 实现内容

设计管道组件注册机制，提高模块化程度。

### 📁 改动文件

| 文件 | 类型 | 改动说明 |
|------|------|---------|
| spikezoo/core/component_registry.py | 新增 | 管道组件注册表，支持插件化扩展 |
| spikezoo/core/__init__.py | 修改 | 导出管道组件注册类 |
| spikezoo/plugins/component_plugin_example.py | 新增 | 管道组件插件示例 |
| examples/component_registration_example.py | 新增 | 管道组件注册使用示例 |
| tests/test_component_registry.py | 新增 | 管道组件注册表单元测试 |

### ✅ 测试结果

**通过 0 个，失败 0 个**

```
无测试文件
```

### ⚠️ Review 注意事项

- **边界情况**：无
- **依赖变更**：无
- **潜在风险**：无

### 🔗 关联

任务：TASK-023　分支：feature/task-023